### PR TITLE
Update figure data inputs and add figures

### DIFF
--- a/bicytok/figures/figureDist1D.py
+++ b/bicytok/figures/figureDist1D.py
@@ -5,14 +5,12 @@ Generates horizontal bar charts to visualize the top 5 markers
 
 Data Import:
 - The CITE-seq dataframe (`importCITE`)
-- Reads a list of epitopes from a CSV file (`epitopeList.csv`)
 
 Parameters:
 - targCell: cell type whose selectivity will be maximized
 - receptors_of_interest: list of receptors to be analyzed
 - sample_size: number of cells to sample for analysis
     (if greater than available cells, will use all)
-- cellTypes: Array of all relevant cell types
 - cell_categorization: column name in CITE-seq dataframe for cell type categorization
 
 Outputs:
@@ -26,7 +24,6 @@ Outputs:
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 from ..distance_metric_funcs import KL_EMD_1D
 from ..imports import importCITE, sample_receptor_abundances
@@ -41,35 +38,23 @@ def makeFigure():
     targCell = "Treg"
     receptors_of_interest = None
     sample_size = 200000
-    cellTypes = np.array(
-        [
-            "CD8 Naive",
-            "NK",
-            "CD8 TEM",
-            "CD4 Naive",
-            "CD4 CTL",
-            "CD8 TCM",
-            "CD8 Proliferating",
-            "Treg",
-        ]
-    )
-    offTargCells = cellTypes[cellTypes != targCell]
     cell_categorization = "CellType2"
 
-    epitopesList = pd.read_csv(path_here / "data" / "epitopeList.csv")
-    epitopes = list(epitopesList["Epitope"].unique())
     CITE_DF = importCITE()
 
     assert targCell in CITE_DF[cell_categorization].unique()
 
+    epitopes = [
+        col
+        for col in CITE_DF.columns
+        if col not in ["CellType1", "CellType2", "CellType3"]
+    ]
     epitopesDF = CITE_DF[epitopes + [cell_categorization]]
-    epitopesDF = epitopesDF.loc[epitopesDF[cell_categorization].isin(cellTypes)]
     epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
     sampleDF = sample_receptor_abundances(
         CITE_DF=epitopesDF,
         numCells=min(sample_size, epitopesDF.shape[0]),
         targCellType=targCell,
-        offTargCellTypes=offTargCells,
     )
     if receptors_of_interest is not None:
         filtered_sampleDF = sampleDF.loc[
@@ -83,7 +68,7 @@ def makeFigure():
     receptors_of_interest = filtered_sampleDF.columns
 
     on_target_mask = (sampleDF["Cell Type"] == targCell).to_numpy()
-    off_target_mask = sampleDF["Cell Type"].isin(offTargCells).to_numpy()
+    off_target_mask = ~on_target_mask
 
     rec_abundances = filtered_sampleDF.to_numpy()
 

--- a/bicytok/figures/figureDist1Dvs2D.py
+++ b/bicytok/figures/figureDist1Dvs2D.py
@@ -3,14 +3,12 @@ Generate plots to compare 1D and 2D distance metrics, which should match.
 
 Data Import:
 - The CITE-seq dataframe (`importCITE`)
-- Reads a list of epitopes from a CSV file (`epitopeList.csv`)
 
 Parameters:
 - targCell: cell type whose selectivity will be maximized
 - receptors_of_interest: list of receptors to be analyzed
 - sample_size: number of cells to sample for analysis
     (if greater than available cells, will use all)
-- cellTypes: Array of all relevant cell types
 - cell_categorization: column name in CITE-seq dataframe for cell type categorization
 
 Outputs:
@@ -43,39 +41,24 @@ def makeFigure():
         "TSLPR",
     ]
     sample_size = 100
-    cellTypes = np.array(
-        [
-            "CD8 Naive",
-            "NK",
-            "CD8 TEM",
-            "CD4 Naive",
-            "CD4 CTL",
-            "CD8 TCM",
-            "CD8 Proliferating",
-            "Treg",
-        ]
-    )
     cell_categorization = "CellType2"
 
-    offTargCells = cellTypes[cellTypes != targCell]
 
     CITE_DF = importCITE()
 
     assert targCell in CITE_DF[cell_categorization].unique()
 
     epitopesDF = CITE_DF[receptors_of_interest + [cell_categorization]]
-    epitopesDF = epitopesDF.loc[epitopesDF[cell_categorization].isin(cellTypes)]
     epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
     sampleDF = sample_receptor_abundances(
         CITE_DF=epitopesDF,
         numCells=sample_size,
         targCellType=targCell,
-        offTargCellTypes=offTargCells,
     )
     rec_abundances = sampleDF[receptors_of_interest].to_numpy()
 
-    target_mask = sampleDF["Cell Type"] == targCell
-    off_target_mask = sampleDF["Cell Type"].isin(offTargCells)
+    target_mask = (sampleDF["Cell Type"] == targCell).to_numpy()
+    off_target_mask = ~target_mask
 
     KL_div_vals_1D, EMD_vals_1D = KL_EMD_1D(
         rec_abundances, target_mask, off_target_mask

--- a/bicytok/figures/figureDist1Dvs2D.py
+++ b/bicytok/figures/figureDist1Dvs2D.py
@@ -43,7 +43,6 @@ def makeFigure():
     sample_size = 100
     cell_categorization = "CellType2"
 
-
     CITE_DF = importCITE()
 
     assert targCell in CITE_DF[cell_categorization].unique()

--- a/bicytok/figures/figureDistHists.py
+++ b/bicytok/figures/figureDistHists.py
@@ -1,0 +1,255 @@
+"""
+Figure file to visualize receptor distributions with the highest and lowest
+distance metrics between target and off-target cell populations.
+
+Data Import:
+- The CITE-seq dataframe (`importCITE`)
+
+Parameters:
+- targCell: cell type whose receptor distributions will be compared to off-target cells
+- sample_size: number of cells to sample for analysis
+- cell_categorization: column name for cell type classification
+
+Outputs:
+- Twenty subplots showing histograms of receptor distributions:
+  - Top 5 receptors by KL divergence
+  - Bottom 5 receptors by KL divergence
+  - Top 5 receptors by EMD
+  - Bottom 5 receptors by EMD
+- Each plot shows target and off-target distributions
+- KL divergence and EMD values are displayed on each plot
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+from ..distance_metric_funcs import KL_EMD_1D
+from ..imports import importCITE, sample_receptor_abundances
+from .common import getSetup
+
+path_here = Path(__file__).parent.parent
+
+plt.rcParams["svg.fonttype"] = "none"
+
+
+def makeFigure():
+    ax, f = getSetup((20, 16), (4, 5))
+
+    # Parameters
+    targCell = "Treg"
+    sample_size = 100
+    cell_categorization = "CellType2"
+
+    # Load and prepare data
+    CITE_DF = importCITE()
+
+    # Ensure target cell exists in the dataset
+    assert (
+        targCell in CITE_DF[cell_categorization].unique()
+    )
+
+    # Sample cells for analysis
+    epitopes = [
+        col
+        for col in CITE_DF.columns
+        if col not in ["CellType1", "CellType2", "CellType3"]
+    ]
+    epitopesDF = CITE_DF[epitopes + [cell_categorization]]
+    epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
+    sampleDF = sample_receptor_abundances(
+        CITE_DF=epitopesDF,
+        numCells=min(sample_size, epitopesDF.shape[0]),
+        targCellType=targCell,
+    )
+
+    # Create target and off-target masks
+    targ_mask = (sampleDF["Cell Type"] == targCell).to_numpy()
+    off_targ_mask = ~targ_mask
+    n_targ = np.sum(targ_mask)
+    n_off_targ = np.sum(off_targ_mask)
+
+    # Filter out any columns with all zero values
+    filtered_sampleDF = sampleDF[sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]]
+    
+    # Filter columns with all zeros in off-target cells
+    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(lambda col: (col == 0).all())
+    filtered_sampleDF = filtered_sampleDF.loc[:, ~off_target_zeros]
+    receptor_columns = filtered_sampleDF.columns
+
+    # Get receptor abundances
+    rec_abundances = filtered_sampleDF.to_numpy()
+
+    # Calculate KL divergence and EMD for all receptors
+    KL_div_vals, EMD_vals = KL_EMD_1D(rec_abundances, targ_mask, off_targ_mask)
+
+    # Create a DataFrame with the results
+    metrics_df = pd.DataFrame(
+        {"Receptor": receptor_columns, "KL_Divergence": KL_div_vals, "EMD": EMD_vals}
+    )
+
+    # Remove NaN values
+    metrics_df = metrics_df.dropna()
+
+    # Sort metrics to find highest and lowest values
+    top_kl_df = metrics_df.nlargest(5, "KL_Divergence")
+    bottom_kl_df = metrics_df.nsmallest(5, "KL_Divergence")
+    top_emd_df = metrics_df.nlargest(5, "EMD")
+    bottom_emd_df = metrics_df.nsmallest(5, "EMD")
+
+    # Organize the plot data by category
+    plot_data = []
+
+    # Row 1: Top 5 KL divergence
+    for i, (_, row) in enumerate(top_kl_df.iterrows()):
+        plot_data.append(
+            {
+                "receptor": row["Receptor"],
+                "kl_val": row["KL_Divergence"],
+                "emd_val": row["EMD"],
+                "category": "Top KL",
+                "plot_idx": i,  # First row
+            }
+        )
+
+    # Row 2: Bottom 5 KL divergence
+    for i, (_, row) in enumerate(bottom_kl_df.iterrows()):
+        plot_data.append(
+            {
+                "receptor": row["Receptor"],
+                "kl_val": row["KL_Divergence"],
+                "emd_val": row["EMD"],
+                "category": "Bottom KL",
+                "plot_idx": i + 5,  # Second row
+            }
+        )
+
+    # Row 3: Top 5 EMD
+    for i, (_, row) in enumerate(top_emd_df.iterrows()):
+        plot_data.append(
+            {
+                "receptor": row["Receptor"],
+                "kl_val": row["KL_Divergence"],
+                "emd_val": row["EMD"],
+                "category": "Top EMD",
+                "plot_idx": i + 10,  # Third row
+            }
+        )
+
+    # Row 4: Bottom 5 EMD
+    for i, (_, row) in enumerate(bottom_emd_df.iterrows()):
+        plot_data.append(
+            {
+                "receptor": row["Receptor"],
+                "kl_val": row["KL_Divergence"],
+                "emd_val": row["EMD"],
+                "category": "Bottom EMD",
+                "plot_idx": i + 15,  # Fourth row
+            }
+        )
+
+    # Plot histograms for each selected receptor
+    for plot_info in plot_data:
+        receptor = plot_info["receptor"]
+        category = plot_info["category"]
+        kl_val = plot_info["kl_val"]
+        emd_val = plot_info["emd_val"]
+        i = plot_info["plot_idx"]
+
+        # Extract receptor abundances and normalize
+        rec_abundance = sampleDF[receptor].values
+        mean_abundance = np.mean(rec_abundance)
+
+        # Normalize by mean abundance
+        targ_abundances = rec_abundance[targ_mask] / mean_abundance
+        off_targ_abundances = rec_abundance[off_targ_mask] / mean_abundance
+
+        # Plot histograms
+        sns.histplot(
+            targ_abundances,
+            ax=ax[i],
+            color="blue",
+            alpha=0.5,
+            label=f"{targCell} (n={n_targ})",
+            stat="density",
+            kde=False,
+        )
+        sns.histplot(
+            off_targ_abundances,
+            ax=ax[i],
+            color="red",
+            alpha=0.5,
+            label=f"Off-target (n={n_off_targ})",
+            stat="density",
+            kde=False,
+        )
+
+        # Add title and labels
+        ax[i].set_title(
+            f"{receptor}\nKL: {kl_val:.2f}, EMD: {emd_val:.2f}", fontsize=10
+        )
+        ax[i].set_xlabel("Normalized Expression", fontsize=9)
+        ax[i].set_ylabel("Density", fontsize=9)
+
+        ax[i].set_xlim(0, 2)
+
+        # Add legend only to first plot in each row
+        if i % 5 == 0:
+            ax[i].legend(loc="upper right", fontsize=8)
+
+        # Add category label as text in corner
+        label_color = {
+            "Top KL": "darkgreen",
+            "Bottom KL": "brown",
+            "Top EMD": "purple",
+            "Bottom EMD": "orange",
+        }
+
+        ax[i].text(
+            0.05,
+            0.95,
+            category,
+            transform=ax[i].transAxes,
+            fontsize=9,
+            fontweight="bold",
+            color=label_color[category],
+            verticalalignment="top",
+            bbox=dict(facecolor="white", alpha=0.7, edgecolor=label_color[category]),
+        )
+
+    # Add row titles
+    row_titles = [
+        "Top 5 KL Divergence",
+        "Bottom 5 KL Divergence",
+        "Top 5 EMD",
+        "Bottom 5 EMD",
+    ]
+
+    for i, title in enumerate(row_titles):
+        # Adding a text label for each row in the figure margin
+        plt.figtext(
+            0.01,
+            0.87 - (i * 0.23),
+            title,
+            fontsize=12,
+            fontweight="bold",
+            rotation=90,
+            ha="center",
+        )
+
+    # Add figure title with summary of metrics ranges
+    kl_range = f"KL div range: [{metrics_df['KL_Divergence'].min():.2f}, {metrics_df['KL_Divergence'].mean():.2f}, {metrics_df['KL_Divergence'].max():.2f}]"
+    emd_range = f"EMD range: [{metrics_df['EMD'].min():.2f}, {metrics_df['EMD'].mean():.2f}, {metrics_df['EMD'].max():.2f}]"
+    plt.suptitle(
+        f"Receptor Distribution Comparison: {targCell} vs Off-Target\n{kl_range}, {emd_range}",
+        fontsize=14,
+    )
+
+    # Adjust layout
+    plt.tight_layout()
+    plt.subplots_adjust(top=0.92, bottom=0.08, left=0.05, right=0.98)
+
+    return f

--- a/bicytok/figures/figureDistHists.py
+++ b/bicytok/figures/figureDistHists.py
@@ -48,9 +48,7 @@ def makeFigure():
     CITE_DF = importCITE()
 
     # Ensure target cell exists in the dataset
-    assert (
-        targCell in CITE_DF[cell_categorization].unique()
-    )
+    assert targCell in CITE_DF[cell_categorization].unique()
 
     # Sample cells for analysis
     epitopes = [
@@ -73,10 +71,14 @@ def makeFigure():
     n_off_targ = np.sum(off_targ_mask)
 
     # Filter out any columns with all zero values
-    filtered_sampleDF = sampleDF[sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]]
-    
+    filtered_sampleDF = sampleDF[
+        sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]
+    ]
+
     # Filter columns with all zeros in off-target cells
-    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(lambda col: (col == 0).all())
+    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(
+        lambda col: (col == 0).all()
+    )
     filtered_sampleDF = filtered_sampleDF.loc[:, ~off_target_zeros]
     receptor_columns = filtered_sampleDF.columns
 
@@ -241,10 +243,18 @@ def makeFigure():
         )
 
     # Add figure title with summary of metrics ranges
-    kl_range = f"KL div range: [{metrics_df['KL_Divergence'].min():.2f}, {metrics_df['KL_Divergence'].mean():.2f}, {metrics_df['KL_Divergence'].max():.2f}]"
-    emd_range = f"EMD range: [{metrics_df['EMD'].min():.2f}, {metrics_df['EMD'].mean():.2f}, {metrics_df['EMD'].max():.2f}]"
+    kl_range = (
+        f"KL div range: [{metrics_df['KL_Divergence'].min():.2f}, "
+        f"{metrics_df['KL_Divergence'].mean():.2f}, "
+        f"{metrics_df['KL_Divergence'].max():.2f}]"
+    )
+    emd_range = (
+        f"EMD range: [{metrics_df['EMD'].min():.2f}, "
+        f"{metrics_df['EMD'].mean():.2f}, {metrics_df['EMD'].max():.2f}]"
+    )
     plt.suptitle(
-        f"Receptor Distribution Comparison: {targCell} vs Off-Target\n{kl_range}, {emd_range}",
+        f"Receptor Distribution Comparison: {targCell} vs Off-Target\n{kl_range}, "
+        f"{emd_range}",
         fontsize=14,
     )
 

--- a/bicytok/figures/figureKLvsEMD.py
+++ b/bicytok/figures/figureKLvsEMD.py
@@ -1,0 +1,227 @@
+"""
+Figure file to visualize the relationship between KL divergence and EMD metrics
+across all receptors, highlighting outliers where metrics significantly disagree.
+
+Data Import:
+- The CITE-seq dataframe (`importCITE`)
+
+Parameters:
+- targCell: cell type whose receptor distributions will be compared to off-target cells
+- sample_size: number of cells to sample for analysis
+- cell_categorization: column name for cell type classification
+
+Outputs:
+- Scatter plot of KL divergence vs EMD for all receptors
+- Highlighted and labeled outlier receptors
+- Summary statistics on the correlation between these metrics
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scipy.stats as stats
+from sklearn.linear_model import LinearRegression
+
+from ..distance_metric_funcs import KL_EMD_1D
+from ..imports import importCITE, sample_receptor_abundances
+from .common import getSetup
+
+path_here = Path(__file__).parent.parent
+
+plt.rcParams["svg.fonttype"] = "none"
+
+
+def makeFigure():
+    ax, f = getSetup((10, 8), (1, 1))
+    ax = ax[0]
+
+    # Parameters
+    targCell = "Treg"
+    sample_size = 100
+    cell_categorization = "CellType2"
+
+    # Load and prepare data
+    CITE_DF = importCITE()
+
+    # Ensure target cell exists in the dataset
+    assert (
+        targCell in CITE_DF[cell_categorization].unique()
+    )
+
+    # Sample cells for analysis
+    epitopes = [
+        col
+        for col in CITE_DF.columns
+        if col not in ["CellType1", "CellType2", "CellType3"]
+    ]
+    epitopesDF = CITE_DF[epitopes + [cell_categorization]]
+    epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
+    sampleDF = sample_receptor_abundances(
+        CITE_DF=epitopesDF,
+        numCells=min(sample_size, epitopesDF.shape[0]),
+        targCellType=targCell,
+    )
+
+    # Create target and off-target masks
+    targ_mask = (sampleDF["Cell Type"] == targCell).to_numpy()
+    off_targ_mask = ~targ_mask
+
+    # Filter out any columns with all zero values
+    filtered_sampleDF = sampleDF[sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]]
+    
+    # Filter columns with all zeros in off-target cells
+    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(lambda col: (col == 0).all())
+    filtered_sampleDF = filtered_sampleDF.loc[:, ~off_target_zeros]
+    receptor_columns = filtered_sampleDF.columns
+
+    # Get receptor abundances
+    rec_abundances = filtered_sampleDF.to_numpy()
+
+    # Calculate KL divergence and EMD for all receptors
+    KL_div_vals, EMD_vals = KL_EMD_1D(rec_abundances, targ_mask, off_targ_mask)
+
+    # Create DataFrame with results, removing NaN values
+    results_df = pd.DataFrame(
+        {"Receptor": receptor_columns, "KL_Divergence": KL_div_vals, "EMD": EMD_vals}
+    ).dropna()
+
+    # Calculate correlation between KL divergence and EMD
+    correlation, _ = stats.pearsonr(
+        results_df["KL_Divergence"], results_df["EMD"]
+    )
+    print(f"Pearson correlation: {correlation:.4f}")
+
+    # Fit a linear regression
+    reg_model = LinearRegression()
+    X = results_df["EMD"].values.reshape(-1, 1)
+    y = results_df["KL_Divergence"].values
+    reg_model.fit(X, y)
+    r_squared = reg_model.score(X, y)
+    slope = reg_model.coef_[0]
+    intercept = reg_model.intercept_
+
+    # Calculate residuals
+    results_df["Predicted_KL"] = intercept + slope * results_df["EMD"]
+    results_df["Residual"] = results_df["KL_Divergence"] - results_df["Predicted_KL"]
+    results_df["Abs_Residual"] = np.abs(results_df["Residual"])
+
+    # Define outliers based on residuals
+    # High KL, Low EMD: Positive residuals (KL higher than predicted from EMD)
+    # Low KL, High EMD: Negative residuals (KL lower than predicted from EMD)
+    residual_threshold = 1.5 * np.std(results_df["Residual"])
+
+    results_df["Outlier_Type"] = "Normal"
+    results_df.loc[results_df["Residual"] > residual_threshold, "Outlier_Type"] = (
+        "High KL, Low EMD"
+    )
+    results_df.loc[results_df["Residual"] < -residual_threshold, "Outlier_Type"] = (
+        "Low KL, High EMD"
+    )
+
+    # Get top outliers in each category
+    high_kl_outliers = results_df[
+        results_df["Outlier_Type"] == "High KL, Low EMD"
+    ].nlargest(5, "Abs_Residual")
+    low_kl_outliers = results_df[
+        results_df["Outlier_Type"] == "Low KL, High EMD"
+    ].nlargest(5, "Abs_Residual")
+
+    # Create a color map for the scatter plot
+    color_map = {
+        "Normal": "gray",
+        "High KL, Low EMD": "red",
+        "Low KL, High EMD": "blue",
+    }
+    colors = [color_map[t] for t in results_df["Outlier_Type"]]
+
+    # Plot the scatter plot
+    scatter = ax.scatter(
+        results_df["EMD"],
+        results_df["KL_Divergence"],
+        alpha=0.6,
+        c=colors,
+        s=30,
+        edgecolors="k",
+        linewidths=0.5,
+    )
+
+    # Add regression line
+    x_range = np.linspace(min(results_df["EMD"]), max(results_df["EMD"]), 100)
+    y_pred = intercept + slope * x_range
+    ax.plot(x_range, y_pred, "k--", label=f"Linear fit (R²={r_squared:.2f})")
+
+    # Label the outliers
+    for _, row in pd.concat([high_kl_outliers, low_kl_outliers]).iterrows():
+        ax.annotate(
+            row["Receptor"],
+            xy=(row["EMD"], row["KL_Divergence"]),
+            xytext=(5, 5),
+            textcoords="offset points",
+            fontsize=9,
+            bbox=dict(boxstyle="round,pad=0.3", fc="white", alpha=0.8),
+        )
+
+    # Add legend for outlier types
+    handles = [
+        plt.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=color,
+            markersize=10,
+            label=label,
+        )
+        for label, color in color_map.items()
+    ]
+    ax.legend(handles=handles, title="Receptor Categories", loc="lower right")
+
+    # Add a text box with correlation information
+    stats_text = (
+        f"Pearson correlation: {correlation:.4f}\n"
+        f"R²: {r_squared:.4f}\n"
+        f"Slope: {slope:.4f}\n"
+        f"# Receptors: {len(results_df)}"
+    )
+    ax.text(
+        0.02,
+        0.98,
+        stats_text,
+        transform=ax.transAxes,
+        verticalalignment="top",
+        horizontalalignment="left",
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+        fontsize=9,
+    )
+
+    # Add summary of outliers at the bottom of the figure
+    outlier_summary = (
+        f"High KL, Low EMD outliers ({len(high_kl_outliers)} shown): {', '.join(high_kl_outliers['Receptor'])}\n"
+        f"Low KL, High EMD outliers ({len(low_kl_outliers)} shown): {', '.join(low_kl_outliers['Receptor'])}"
+    )
+    plt.figtext(
+        0.5,
+        0.01,
+        outlier_summary,
+        ha="center",
+        fontsize=9,
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+    )
+
+    # Set titles and labels
+    ax.set_title(
+        f"KL Divergence vs EMD for {targCell} vs Off-target Cells", fontsize=12
+    )
+    ax.set_xlabel("Earth Mover's Distance (EMD)", fontsize=11)
+    ax.set_ylabel("KL Divergence", fontsize=11)
+
+    # Set axis properties
+    ax.grid(True, linestyle="--", alpha=0.7)
+
+    # Adjust layout
+    plt.tight_layout()
+    plt.subplots_adjust(bottom=0.15)
+
+    return f

--- a/bicytok/figures/figureKLvsEMD.py
+++ b/bicytok/figures/figureKLvsEMD.py
@@ -46,9 +46,7 @@ def makeFigure():
     CITE_DF = importCITE()
 
     # Ensure target cell exists in the dataset
-    assert (
-        targCell in CITE_DF[cell_categorization].unique()
-    )
+    assert targCell in CITE_DF[cell_categorization].unique()
 
     # Sample cells for analysis
     epitopes = [
@@ -69,10 +67,14 @@ def makeFigure():
     off_targ_mask = ~targ_mask
 
     # Filter out any columns with all zero values
-    filtered_sampleDF = sampleDF[sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]]
-    
+    filtered_sampleDF = sampleDF[
+        sampleDF.columns[~sampleDF.columns.isin(["Cell Type"])]
+    ]
+
     # Filter columns with all zeros in off-target cells
-    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(lambda col: (col == 0).all())
+    off_target_zeros = filtered_sampleDF.loc[off_targ_mask].apply(
+        lambda col: (col == 0).all()
+    )
     filtered_sampleDF = filtered_sampleDF.loc[:, ~off_target_zeros]
     receptor_columns = filtered_sampleDF.columns
 
@@ -88,9 +90,7 @@ def makeFigure():
     ).dropna()
 
     # Calculate correlation between KL divergence and EMD
-    correlation, _ = stats.pearsonr(
-        results_df["KL_Divergence"], results_df["EMD"]
-    )
+    correlation, _ = stats.pearsonr(results_df["KL_Divergence"], results_df["EMD"])
     print(f"Pearson correlation: {correlation:.4f}")
 
     # Fit a linear regression
@@ -137,7 +137,7 @@ def makeFigure():
     colors = [color_map[t] for t in results_df["Outlier_Type"]]
 
     # Plot the scatter plot
-    scatter = ax.scatter(
+    ax.scatter(
         results_df["EMD"],
         results_df["KL_Divergence"],
         alpha=0.6,
@@ -198,8 +198,10 @@ def makeFigure():
 
     # Add summary of outliers at the bottom of the figure
     outlier_summary = (
-        f"High KL, Low EMD outliers ({len(high_kl_outliers)} shown): {', '.join(high_kl_outliers['Receptor'])}\n"
-        f"Low KL, High EMD outliers ({len(low_kl_outliers)} shown): {', '.join(low_kl_outliers['Receptor'])}"
+        f"High KL, Low EMD outliers ({len(high_kl_outliers)} shown): "
+        f"{', '.join(high_kl_outliers['Receptor'])}\n"
+        f"Low KL, High EMD outliers ({len(low_kl_outliers)} shown): "
+        f"{', '.join(low_kl_outliers['Receptor'])}"
     )
     plt.figtext(
         0.5,

--- a/bicytok/figures/figureSelec2D.py
+++ b/bicytok/figures/figureSelec2D.py
@@ -9,8 +9,8 @@ Parameters:
 - receptors: list of receptors to be analyzed
 - cell_type: cell type whose selectivity will be maximized
 - dose: dose of ligand to be used in the selectivity calculation
-- cellTypes: Array of all relevant cell types
 - valency: valency of the complex to be used in the selectivity calculation
+- cell_categorization: column name in CITE-seq dataframe for cell type categorization
 
 Outputs:
 - Displays the optimal selectivities of all relevant receptor pairs in a heatmap
@@ -36,32 +36,21 @@ def makeFigure():
     cell_type = "Treg"
     dose = 10e-2
     valency = np.array([[2, 2]])
-    cellTypes = np.array(
-        [
-            "CD8 Naive",
-            "NK",
-            "CD8 TEM",
-            "CD4 Naive",
-            "CD4 CTL",
-            "CD8 TCM",
-            "CD8 Proliferating",
-            "Treg",
-        ]
-    )
-
-    offTargCells = cellTypes[cellTypes != cell_type]
+    cell_categorization = "CellType2"
 
     CITE_DF = importCITE()
 
-    filt_cols = ["CellType1", "CellType3", "Cell"]
-    marker_columns = CITE_DF.columns[~CITE_DF.columns.isin(filt_cols)]
-    markerDF = CITE_DF.loc[:, marker_columns]
-    markerDF = markerDF.rename(columns={"CellType2": "Cell Type"})
-
-    sampleDF = sample_receptor_abundances(markerDF, 50, cell_type, offTargCells)
+    epitopes = [
+        col
+        for col in CITE_DF.columns
+        if col not in ["CellType1", "CellType2", "CellType3"]
+    ]
+    epitopesDF = CITE_DF[epitopes + [cell_categorization]]
+    epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
+    sampleDF = sample_receptor_abundances(epitopesDF, 100, cell_type)
 
     targ_mask = (sampleDF["Cell Type"] == cell_type).to_numpy()
-    off_targ_mask = sampleDF["Cell Type"].isin(offTargCells).to_numpy()
+    off_targ_mask = ~targ_mask
 
     selectivities = np.full((len(receptors), len(receptors)), np.nan)
     for i, rec1 in enumerate(receptors):

--- a/bicytok/figures/figureVariationAnalysis.py
+++ b/bicytok/figures/figureVariationAnalysis.py
@@ -51,7 +51,6 @@ def makeFigure():
     dose = 10e-2
     cell_categorization = "CellType2"
 
-
     # Imports
     CITE_DF = importCITE()
 

--- a/bicytok/figures/figureVariationAnalysis.py
+++ b/bicytok/figures/figureVariationAnalysis.py
@@ -4,7 +4,6 @@ Generates box plots to visualize the relationship between sample size and the
 
 Data Import:
 - The CITE-seq dataframe (`importCITE`)
-- Reads a list of epitopes from a CSV file (`epitopeList.csv`)
 
 Parameters:
 - sample_sizes: list of sample sizes to be tested
@@ -14,7 +13,6 @@ Parameters:
 - valencies: valency of the complex
 - targets: receptor pair on which the variation will be tested
 - dose: dose of ligand to be used in the selectivity calculation
-- cellTypes: Array of all relevant cell types
 - cell_categorization: column name in CITE-seq dataframe for cell type categorization
 
 Outputs:
@@ -51,21 +49,8 @@ def makeFigure():
     valencies = np.array([[1, 1, 1]])
     targets = ["CD25", "CD278"]
     dose = 10e-2
-    cellTypes = np.array(
-        [
-            "CD8 Naive",
-            "NK",
-            "CD8 TEM",
-            "CD4 Naive",
-            "CD4 CTL",
-            "CD8 TCM",
-            "CD8 Proliferating",
-            "Treg",
-        ]
-    )
     cell_categorization = "CellType2"
 
-    offTargCells = cellTypes[cellTypes != targCell]
 
     # Imports
     CITE_DF = importCITE()
@@ -73,19 +58,17 @@ def makeFigure():
     assert targCell in CITE_DF[cell_categorization].unique()
 
     epitopesDF = CITE_DF[[signal_receptor] + targets + [cell_categorization]]
-    epitopesDF = epitopesDF.loc[epitopesDF[cell_categorization].isin(cellTypes)]
     epitopesDF = epitopesDF.rename(columns={cell_categorization: "Cell Type"})
     sampleDF = sample_receptor_abundances(
         CITE_DF=epitopesDF,
         numCells=epitopesDF.shape[0],
         targCellType=targCell,
-        offTargCellTypes=offTargCells,
     )
 
     metrics = []
     for sample_size in sample_sizes:
         target_cells = sampleDF[sampleDF["Cell Type"] == targCell]
-        off_target_cells = sampleDF[sampleDF["Cell Type"].isin(offTargCells)]
+        off_target_cells = sampleDF[sampleDF["Cell Type"] != targCell]
 
         num_target_cells = sample_size // 2
         num_off_target_cells = sample_size - num_target_cells
@@ -103,7 +86,7 @@ def makeFigure():
 
             # Define target and off-target cell masks (for distance metrics)
             target_mask = (rand_samples["Cell Type"] == targCell).to_numpy()
-            off_target_mask = rand_samples["Cell Type"].isin(offTargCells).to_numpy()
+            off_target_mask = ~target_mask
 
             # Calculate distance metrics
             rec_abundances = rand_samples[targets].to_numpy()

--- a/bicytok/imports.py
+++ b/bicytok/imports.py
@@ -241,7 +241,7 @@ def sample_receptor_abundances(
     CITE_DF: pd.DataFrame,
     numCells: int,
     targCellType: str,
-    offTargCellTypes: list[str],
+    offTargCellTypes: list[str] = None,
     rand_state: int = 42,
 ) -> pd.DataFrame:
     """
@@ -255,7 +255,8 @@ def sample_receptor_abundances(
         numCells: number of cells to sample
         targCellType: the cell type that will be used to split target and
             off targer sampling
-        offTargCellTypes: list of cell types that are distinct from target cells
+        offTargCellTypes: list of cell types that are distinct from target cells.
+            If None, all cell types except targCellType will be used.
         rand_state: random seed for reproducibility
     Return:
         sampleDF: dataframe containing single cell abundances of
@@ -268,7 +269,10 @@ def sample_receptor_abundances(
 
     # Sample an equal number of target and off-target cells
     target_cells = CITE_DF[CITE_DF["Cell Type"] == targCellType]
-    off_target_cells = CITE_DF[CITE_DF["Cell Type"].isin(offTargCellTypes)]
+    if offTargCellTypes is not None:
+        off_target_cells = CITE_DF[CITE_DF["Cell Type"].isin(offTargCellTypes)]
+    else:
+        off_target_cells = CITE_DF[CITE_DF["Cell Type"] != targCellType]
 
     num_target_cells = numCells // 2
     num_off_target_cells = numCells - num_target_cells


### PR DESCRIPTION
Existing figure changes:
- Remove epitope filters: previously, the majority of epitopes were removed from the data set before figure generation. Now, all epitopes are included in all figures.
- Remove cell type filters: previously, only a subset of cell types were included in the data set given to figures. Roughly 60,000 of the 160,000 cells were removed. Now, all cell types and all cells are included in all figures.
- Unified filtration steps: previously, all figures had slight variation in which cell types/epitopes were filtered and how they were filtered. Now, all figures utilize the same data and are filtered in the same manner.

Figures added:
- DistHists: plots histograms of the on and off target populations' receptor distributions. Twenty receptors are plotted - those in the top five EMD, top five KL div, bottom five EMD, and bottom five KL div (all 1D). The goal of this figure is to show which receptors have high/low distance metric values and what aspects of their on/off target distributions lead to these values.
- KLvsEMD: plots a scatter plot of 1D KL divergence vs EMD for all receptors and highlights outliers. The goal of this figure is to see how well KL div and EMD agree, and to identify cases where the distance metrics disagree heavily.

Notes:
- Could eventually add a "filtration" function to imports.py because all figures now use the same filtration scheme. Before I do this, I want to identify which epitopes/cell types should actually be filtered, because I'm sure there are some.