### PR TITLE
Sweep expression normalization

### DIFF
--- a/figures/scanning_analyses/scan_runners.py
+++ b/figures/scanning_analyses/scan_runners.py
@@ -38,7 +38,7 @@ def run_selectivity_scan():
 
     # Binding model parameters
     dose = 1e-10
-    valency = np.array([[1, 2, 2]])
+    valency = np.array([[1, 1, 1]])
     init = [6.0, 7.0, 7.0, -9.0] # Initial optimization values
     signal = "prototype" # Define signal receptor; "prototype" or receptor name
     asym_targs = False # Calculates both symmetric cases (rec1, rec2) and (rec2, rec1)
@@ -78,7 +78,8 @@ def run_selectivity_scan():
     rec_abundances = epitopes_df.drop(columns=["Cell Type"]).to_numpy()
     if expr_matching is not None:
         for i, rec in enumerate(receptors):
-            rec_abundances[:, i] = rec_abundances[:, i] * expr_matching / np.mean(rec_abundances[:, i])
+            if i != signal_ind and signal != "prototype":  # Don't scale the signal receptor if it's the prototype
+                rec_abundances[:, i] = rec_abundances[:, i] * expr_matching / np.mean(rec_abundances[:, i])
 
     # Define cell type labels if not pre-specified
     cell_type_labels = epitopes_df["Cell Type"].tolist()

--- a/figures/scanning_analyses/scan_runners.py
+++ b/figures/scanning_analyses/scan_runners.py
@@ -31,26 +31,9 @@ def run_selectivity_scan():
     sample_size = 1000
     min_avg_count = 5 # Expression threshold
     receptors = None # Receptors to analyze; list or None for all
-    cell_types = [ # Cell types to analyze; list or None for all
-        "Treg",
-        "dnT",
-        "CD4 CTL",
-        "CD8 Proliferating",
-        "CD4 TCM",
-        "B memory",
-        "CD8 TCM",
-        "CD8 Naive",
-        "CD4 Proliferating",
-        "NK_CD56bright",
-        "CD4 Naive",
-        "CD8 TEM",
-        "ILC",
-        "CD4 TEM",
-        "B naive",
-        "NK",
-    ]
-    targ_cell_types = ["Treg"] # Target cell types for selectivity calculation; list or None for all
-    exclude_cell_types = True # Boolean to exclude cell types not in cell_types list
+    cell_types = None # Cell types to analyze; list or None for all
+    targ_cell_types = None # Target cell types for selectivity calculation; list or None for all
+    exclude_cell_types = False # Boolean to exclude cell types not in cell_types list
     expr_matching = 100 # If not None, scales receptor expression values to match this average across all cell types
 
     # Binding model parameters
@@ -196,31 +179,13 @@ def run_KL_EMD_scan():
     sample_size = 1000
     min_avg_count = 5 # Expression threshold
     receptors = None # Receptors to analyze; list or None for all
-    cell_types = [ # Cell types to analyze; list or None for all
-        "Treg",
-        "dnT",
-        "CD4 CTL",
-        "CD8 Proliferating",
-        "CD4 TCM",
-        "B memory",
-        "CD8 TCM",
-        "CD8 Naive",
-        "CD4 Proliferating",
-        "NK_CD56bright",
-        "CD4 Naive",
-        "CD8 TEM",
-        "ILC",
-        "CD4 TEM",
-        "B naive",
-        "NK",
-    ]
-    targ_cell_types = ["Treg"] # Target cell types for selectivity calculation; list or None for all
-    exclude_cell_types = True # Boolean to exclude cell types not in cell_types list
+    cell_types = None # Cell types to analyze; list or None for all
+    targ_cell_types = None # Target cell types for selectivity calculation; list or None for all
+    exclude_cell_types = False # Boolean to exclude cell types not in cell_types list
     expr_matching = 100 # If not None, scales receptor expression values to match this average across all cell types
 
-
     # Distance metric scan parameters
-    filter_by_target_expr = True # Boolean to filter out receptors with higher off-target expression
+    filter_by_target_expr = False # Boolean to filter out receptors with higher off-target expression
 
     # Load and define receptor set
     CITE_DF = importCITE()

--- a/figures/scanning_analyses/scan_runners.py
+++ b/figures/scanning_analyses/scan_runners.py
@@ -51,6 +51,7 @@ def run_selectivity_scan():
     ]
     targ_cell_types = ["Treg"] # Target cell types for selectivity calculation; list or None for all
     exclude_cell_types = True # Boolean to exclude cell types not in cell_types list
+    expr_matching = 100 # If not None, scales receptor expression values to match this average across all cell types
 
     # Binding model parameters
     dose = 1e-10
@@ -90,11 +91,16 @@ def run_selectivity_scan():
     if cell_types is not None and exclude_cell_types:
         epitopes_df = epitopes_df[epitopes_df["Cell Type"].isin(cell_types)]
 
+    # Match receptor abundance averages
     rec_abundances = epitopes_df.drop(columns=["Cell Type"]).to_numpy()
+    if expr_matching is not None:
+        for i, rec in enumerate(receptors):
+            rec_abundances[:, i] = rec_abundances[:, i] * expr_matching / np.mean(rec_abundances[:, i])
+
+    # Define cell type labels if not pre-specified
     cell_type_labels = epitopes_df["Cell Type"].tolist()
     if cell_types is None:
         cell_types = list(set(cell_type_labels))
-
     if targ_cell_types is None:
         targ_cell_types = cell_types
     
@@ -150,6 +156,7 @@ def run_selectivity_scan():
             "min_expression_threshold": min_avg_count,
             "exclude_unused_cell_types": exclude_cell_types,
             "dim": 2,
+            "expr_matching": expr_matching,
         },
         "binding_model": {
             "dose": float(dose),
@@ -209,6 +216,8 @@ def run_KL_EMD_scan():
     ]
     targ_cell_types = ["Treg"] # Target cell types for selectivity calculation; list or None for all
     exclude_cell_types = True # Boolean to exclude cell types not in cell_types list
+    expr_matching = 100 # If not None, scales receptor expression values to match this average across all cell types
+
 
     # Distance metric scan parameters
     filter_by_target_expr = True # Boolean to filter out receptors with higher off-target expression
@@ -232,11 +241,16 @@ def run_KL_EMD_scan():
     if cell_types is not None and exclude_cell_types:
         epitopes_df = epitopes_df[epitopes_df["Cell Type"].isin(cell_types)]
 
+    # Match receptor abundance averages
     rec_abundances = epitopes_df.drop(columns=["Cell Type"]).to_numpy()
+    if expr_matching is not None:
+        for i, rec in enumerate(receptors):
+            rec_abundances[:, i] = rec_abundances[:, i] * expr_matching / np.mean(rec_abundances[:, i])
+
+    # Define cell type labels if not pre-specified
     cell_type_labels = epitopes_df["Cell Type"].tolist()
     if cell_types is None:
         cell_types = list(set(cell_type_labels))
-
     if targ_cell_types is None:
         targ_cell_types = cell_types
     
@@ -282,6 +296,7 @@ def run_KL_EMD_scan():
             "min_expression_threshold": min_avg_count,
             "exclude_unused_cell_types": exclude_cell_types,
             "dim": 2,
+            "expr_matching": expr_matching,
         },
         "distance_metric": {
             "filter_by_target_expr": filter_by_target_expr,


### PR DESCRIPTION
This pull request updates the scanning analysis scripts to make the selection of cell types and target cell types more flexible, introduces an option to normalize receptor expression levels across cell types, and adjusts several default analysis parameters. These changes help generalize the code for broader use cases and improve control over receptor abundance normalization.

Key changes:
* Added an `expr_matching` parameter (default 100) to optionally normalize receptor expression values to a common average across all cell types, improving comparability between analyses. [[1]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694L34-R41) [[2]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694L192-R189)
* Implemented logic to scale receptor abundances so their mean matches the `expr_matching` value, with special handling to avoid scaling the signal receptor in the prototype case. [[1]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694R77-L97) [[2]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694R210-L239)
* Included the new `expr_matching` parameter in the output metadata for both selectivity and KL/EMD scans, ensuring reproducibility and clarity in analysis records. [[1]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694R143) [[2]](diffhunk://#diff-14c4bf549297b8f2ab4b3c29eb0eda90ec15036b2bdcc3e29f4fe30b82a5c694R265)