### PR TITLE
Manuscript figure setup

### DIFF
--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -1,10 +1,15 @@
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 
-FONT_FAMILY = "serif"
-FONT_NAME = "Times New Roman"  # matches manuscript mainfont in _quarto.yml
+FONT_FAMILY = "sans-serif"
+FONT_NAME = "Myriad Pro"  # temporary override for comparison; manuscript mainfont in
+# _quarto.yml is still Times New Roman, so figures are out of sync with body text for now
 
 FONT_SIZE_TITLE = 14
+FONT_SIZE_LABEL = 22
+FONT_SIZE_TICK = 20
+FONT_SIZE_LEGEND = 18
+FONT_SIZE_ANNOT = 16  # in-plot data annotations (heatmap cell labels, point/bar labels)
 
 DEFAULT_N_TICKS = 6  # default tick count per axis; override per-plot via set_tick_count
 
@@ -15,7 +20,7 @@ LINE_WIDTH_AGGREGATE = (
 POINT_SIZE_XS = 7  # extra small scatter points (scatters containing entire scan)
 POINT_SIZE_BACKGROUND = 15  # bulk / non-emphasized scatter points
 POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star markers)
-GRID_ALPHA = 0.3
+GRID_ALPHA = 0.4
 GRID_LINESTYLE = "--"
 LEGEND_FRAMEALPHA = 0.8
 LEGEND_BORDERPAD = 0.3  # padding between legend border and its content (default 0.4)
@@ -94,7 +99,7 @@ CELL_TYPES = [
 ]
 
 FIGSIZE = {
-    "single_panel": (4, 3),  # single 1D histogram/line panel
+    "single_panel": (5, 3),  # single 1D histogram/line panel
     "square_scatter": (4, 4),  # single square scatter panel
     "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
     "square_heatmap": (5, 5),  # single square heatmap panel with colorbar
@@ -259,7 +264,7 @@ def apply_style() -> None:
     plt.rcParams.update(
         {
             "font.family": FONT_FAMILY,
-            "font.serif": [FONT_NAME],
+            f"font.{FONT_FAMILY}": [FONT_NAME],
             "svg.fonttype": "none",
             "axes.titlesize": FONT_SIZE_TITLE,
             "axes.labelsize": FONT_SIZE_LABEL,

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -13,7 +13,7 @@ LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
     2.5  # emphasizes summary/aggregate overlays (e.g. "All off-target")
 )
-POINT_SIZE_XS = 7 # extra small scatter points (scatters containing entire scan)
+POINT_SIZE_XS = 7  # extra small scatter points (scatters containing entire scan)
 POINT_SIZE_BACKGROUND = 15  # bulk / non-emphasized scatter points
 POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star markers)
 GRID_ALPHA = 0.3
@@ -50,6 +50,49 @@ CMAPS = {
     "categorical": "tab10",  # qualitative palette for <=10 subgroups
     "categorical_large": "tab20",  # qualitative palette for >10 subgroups
 }
+
+# CITE-seq CellType2 annotation values (see bicytok.imports.importCITE), fixed here so a
+# given cell type always gets the same color everywhere it's plotted, regardless of which
+# subset of cell types happens to be present in a particular scan or comparison. Without
+# this, per-plot palettes built from `categorical_colors(len(cell_types_present), ...)`
+# assign colors by *position in the current subset*, so the same cell type can land on a
+# different color in every plot — or, worse, on the exact same color as an unrelated cell
+# type whenever both subsets happen to have length 1 (confirmed happening in practice:
+# Treg / CD8 TCM / pDC's single-cell-type panels in scan_comparison_scatter.qmd all drew
+# the same color, since `categorical_colors(1, ...)` always returns the first sample).
+CELL_TYPES = [
+    "ASDC",
+    "B intermediate",
+    "B memory",
+    "B naive",
+    "CD14 Mono",
+    "CD16 Mono",
+    "CD4 CTL",
+    "CD4 Naive",
+    "CD4 Proliferating",
+    "CD4 TCM",
+    "CD4 TEM",
+    "CD8 Naive",
+    "CD8 Proliferating",
+    "CD8 TCM",
+    "CD8 TEM",
+    "Doublet",
+    "Eryth",
+    "HSPC",
+    "ILC",
+    "MAIT",
+    "NK",
+    "NK Proliferating",
+    "NK_CD56bright",
+    "Plasmablast",
+    "Platelet",
+    "Treg",
+    "cDC1",
+    "cDC2",
+    "dnT",
+    "gdT",
+    "pDC",
+]
 
 FIGSIZE = {
     "single_panel": (4, 3),  # single 1D histogram/line panel
@@ -115,6 +158,39 @@ def categorical_colors(n: int, cmap_name: str = CMAPS["categorical"]) -> list:
     """
     cmap = plt.colormaps.get_cmap(cmap_name).resampled(n)
     return [cmap(i) for i in range(n)]
+
+
+def discrete_categorical_colors(n: int, cmap_names: list[str]) -> list:
+    """
+    Returns n distinct qualitative colors by concatenating the *discrete* entries
+    of one or more qualitative colormaps, without interpolating between entries
+    the way `categorical_colors`' `resampled(n)` does.
+
+    Interpolating a 20-color map down to, say, 12 categories blends adjacent
+    entries into new in-between colors that can look muddier and less distinct
+    than the original discrete set. Concatenating whole discrete palettes (e.g.
+    tab20 + tab20b + tab20c) avoids that, at the cost of needing enough total
+    entries across the given maps to cover n.
+
+    :param n: Number of distinct colors needed
+    :param cmap_names: Qualitative matplotlib colormaps to concatenate, in order
+    :return: List of n RGBA color tuples
+    """
+    colors = [c for name in cmap_names for c in plt.colormaps.get_cmap(name).colors]
+    assert len(colors) >= n, (
+        f"Only {len(colors)} discrete colors available across {cmap_names}, need {n}"
+    )
+    return colors[:n]
+
+
+# Canonical cell-type -> color mapping, built once from the fixed CELL_TYPES list above.
+CELL_TYPE_COLORS = dict(
+    zip(
+        CELL_TYPES,
+        discrete_categorical_colors(len(CELL_TYPES), ["tab20", "tab20b", "tab20c"]),
+        strict=True,
+    )
+)
 
 
 def standalone_legend_figure(handles: list, labels: list[str], **legend_kwargs):

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -1,0 +1,81 @@
+import matplotlib.pyplot as plt
+
+FONT_FAMILY = "serif"
+FONT_NAME = "Times New Roman"  # matches manuscript mainfont in _quarto.yml
+
+FONT_SIZE_TITLE = 14
+FONT_SIZE_LABEL = 12
+FONT_SIZE_TICK = 10
+FONT_SIZE_LEGEND = 10
+FONT_SIZE_ANNOT = 10  # in-plot data annotations (heatmap cell labels, point/bar labels)
+
+LINE_WIDTH = 1.5
+LINE_WIDTH_AGGREGATE = (
+    2.5  # emphasizes summary/aggregate overlays (e.g. "All off-target")
+)
+GRID_ALPHA = 0.3
+GRID_LINESTYLE = "--"
+LEGEND_FRAMEALPHA = 0.8
+
+COLORS = {
+    "target": "#CF4D6F",  # as currently used in raw_1D-hist.qmd
+    "off_target": "#2774AE",  # anchor color
+    "aggregate": "darkred",  # summary overlay across a group (e.g. "All off-target")
+    "improved": "#2774AE",  # 2D metric >= 1D metric (pairing helps); anchor color
+    "declined": "#C0392B",  # 2D metric < 1D metric (pairing hurts)
+}
+
+LINESTYLES = {
+    "aggregate": "--",  # dashed, distinguishes summary overlays from individual series
+}
+
+CMAPS = {
+    "sequential": "Reds",  # magnitude-only heatmap data (e.g. optimal metric value)
+    "categorical": "tab10",  # qualitative palette for <=10 subgroups
+    "categorical_large": "tab20",  # qualitative palette for >10 subgroups
+}
+
+FIGSIZE = {
+    "single_panel": (5, 3),  # single 1D histogram/line panel
+    "square_scatter": (7, 7),  # single square scatter panel
+    "joint_grid": (10, 8),  # 2D joint distribution + marginal histograms
+    "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
+}
+
+
+def categorical_colors(n: int, cmap_name: str = CMAPS["categorical"]) -> list:
+    """
+    Returns n distinct qualitative colors for identifying arbitrary subgroups
+    (e.g. individual off-target cell types, cell types in a scan comparison).
+
+    :param n: Number of distinct colors needed
+    :param cmap_name: Name of a qualitative matplotlib colormap to sample
+    :return: List of n RGBA color tuples
+    """
+    cmap = plt.colormaps.get_cmap(cmap_name).resampled(n)
+    return [cmap(i) for i in range(n)]
+
+
+def apply_style() -> None:
+    """
+    Applies shared rcParams so figures intended for publication/posters share a
+    common font, size hierarchy, line width, legend style, and grid style.
+    """
+    plt.rcParams.update(
+        {
+            "font.family": FONT_FAMILY,
+            "font.serif": [FONT_NAME],
+            "svg.fonttype": "none",
+            "axes.titlesize": FONT_SIZE_TITLE,
+            "axes.labelsize": FONT_SIZE_LABEL,
+            "xtick.labelsize": FONT_SIZE_TICK,
+            "ytick.labelsize": FONT_SIZE_TICK,
+            "legend.fontsize": FONT_SIZE_LEGEND,
+            "legend.title_fontsize": FONT_SIZE_LEGEND,
+            "legend.framealpha": LEGEND_FRAMEALPHA,
+            "lines.linewidth": LINE_WIDTH,
+            "axes.grid": True,
+            "grid.alpha": GRID_ALPHA,
+            "grid.linestyle": GRID_LINESTYLE,
+        }
+    )

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -1,12 +1,11 @@
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 
-FONT_FAMILY = "sans-serif"
-FONT_NAME = "Myriad Pro"  # temporary override for comparison; manuscript mainfont in
-# _quarto.yml is still Times New Roman, so figures are out of sync with body text for now
-
+## Shared rcParams, set in-figure via apply_style() call
+FONT_FAMILY = "serif"
+FONT_NAME = "Times New Roman"  # should match the font used in Quarto's PDF output (see _quarto.yml)
 FONT_SIZE_TITLE = 22
-FONT_SIZE_LABEL = 22
+FONT_SIZE_LABEL = 22  # axis labels
 FONT_SIZE_TICK = 20
 FONT_SIZE_LEGEND = 18
 FONT_SIZE_ANNOT = 16  # in-plot data annotations (heatmap cell labels, point/bar labels)
@@ -17,11 +16,13 @@ LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
     2.5  # emphasizes summary/aggregate overlays (e.g. "All off-target")
 )
+GRID_ALPHA = 0.4
+GRID_LINESTYLE = "--"
+
 POINT_SIZE_XS = 7  # extra small scatter points (scatters containing entire scan)
 POINT_SIZE_BACKGROUND = 15  # bulk / non-emphasized scatter points
 POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star markers)
-GRID_ALPHA = 0.4
-GRID_LINESTYLE = "--"
+
 LEGEND_FRAMEALPHA = 0.8
 LEGEND_BORDERPAD = 0.3  # padding between legend border and its content (default 0.4)
 LEGEND_LABELSPACING = 0.3  # vertical space between entries (default 0.5)
@@ -29,26 +30,29 @@ LEGEND_HANDLELENGTH = 1.5  # length of the marker/line handle sample (default 2.
 LEGEND_HANDLETEXTPAD = 0.5  # space between handle and label text (default 0.8)
 LEGEND_BORDERAXESPAD = 0.3  # space between legend and axes edge (default 0.5)
 
+
+## Shared figure styles, imported and applied in-figure
+_MAIN_BLUE = "#1d75bc"
+_MAIN_RED = "#f0554f"
+_MAIN_ORANGE = "#f7941d"
 COLORS = {
-    "target": "#CF4D6F",  # as currently used in raw_1D-hist.qmd
-    "off_target": "#2774AE",  # anchor color
-    "aggregate": "darkred",  # summary overlay across a group (e.g. "All off-target")
-    "improved": "#2774AE",  # 2D metric >= 1D metric (pairing helps); anchor color
-    "declined": "#C0392B",  # 2D metric < 1D metric (pairing hurts)
-    "Treg": "#1e75bc",
-    "CD8 T": "#f7941d",
-    "NK": "#f0554f",
+    "target": _MAIN_RED,  # target cell type color (raw_1D-hist.qmd, etc.)
+    "off_target": _MAIN_BLUE,  # anchor color
+    "aggregate": "darkred",  # summary overlay across a group (e.g. "All off-target") in off_targ_breakdown.qmd
+    "improved": _MAIN_BLUE,  # 2D metric >= 1D metric (pairing helps) in scan_top_hits_1Dvs2D.qmd
+    "declined": _MAIN_RED,  # 2D metric < 1D metric (pairing hurts) in scan_top_hits_1Dvs2D.qmd
+    "Treg": _MAIN_BLUE,  # consistent specific cell type colors across figures
+    "CD8 T": _MAIN_ORANGE,
+    "NK": _MAIN_RED,
     "outlier_neither": "lightgray",  # scan_outliers.qmd: neither metric is high
-    "outlier_metric1": "#3A86FF",  # scan_outliers.qmd: metric 1 outlier
-    "outlier_metric2": "#FF9F1C",  # scan_outliers.qmd: metric 2 outlier
-    "outlier_both": "#E63946",  # scan_outliers.qmd: high on both metrics
+    "outlier_metric1": _MAIN_BLUE,  # scan_outliers.qmd: metric 1 outlier
+    "outlier_metric2": _MAIN_ORANGE,  # scan_outliers.qmd: metric 2 outlier
+    "outlier_both": _MAIN_RED,  # scan_outliers.qmd: high on both metrics
     "outlier_user": "#9B5DE5",  # scan_outliers.qmd: user-specified pairs
 }
 
-# Shared palette for "two binary conditions crossed" categorical breakdowns (4 categories:
-# neither, condition A only, condition B only, both) — used by scan_outliers.qmd's outlier
-# categories (COLORS["outlier_*"] above) and by the co-pinning / selectivity-gain flow
-# diagrams in scan_kxstar_bounds.qmd, which share the same category shape.
+# Shared palette for "two binary conditions crossed" categorical breakdowns, used by
+# scan_outliers.qmd and scan_kxstar_bounds.qmd
 CROSSED_CONDITION_COLORS = [
     COLORS["outlier_neither"],
     COLORS["outlier_metric1"],
@@ -56,25 +60,36 @@ CROSSED_CONDITION_COLORS = [
     COLORS["outlier_both"],
 ]
 
-LINESTYLES = {
-    "aggregate": "--",  # dashed, distinguishes summary overlays from individual series
-}
-
 CMAPS = {
     "sequential": "Reds",  # magnitude-only heatmap data (e.g. optimal metric value)
     "categorical": "tab10",  # qualitative palette for <=10 subgroups
     "categorical_large": "tab20",  # qualitative palette for >10 subgroups
 }
 
-# CITE-seq CellType2 annotation values (see bicytok.imports.importCITE), fixed here so a
-# given cell type always gets the same color everywhere it's plotted, regardless of which
-# subset of cell types happens to be present in a particular scan or comparison. Without
-# this, per-plot palettes built from `categorical_colors(len(cell_types_present), ...)`
-# assign colors by *position in the current subset*, so the same cell type can land on a
-# different color in every plot — or, worse, on the exact same color as an unrelated cell
-# type whenever both subsets happen to have length 1 (confirmed happening in practice:
-# Treg / CD8 TCM / pDC's single-cell-type panels in scan_comparison_scatter.qmd all drew
-# the same color, since `categorical_colors(1, ...)` always returns the first sample).
+FIGSIZE = {
+    "single_panel": (5, 4),  # rectangular panel (histograms, barplots, etc.)
+    "square_scatter": (4, 4),  # small square panel (scatterplots, etc.)
+    "joint_grid": (
+        5,
+        4,
+    ),  # 2D joint distribution + marginal histograms (raw_2D-hist.qmd)
+    "square_heatmap": (6, 6),  # large square panel (heatmaps, etc.)
+    "alluvial_flow": (3, 7),  # category-transition alluvial (scan_kxstar_bounds.qmd)
+    "alluvial_flow_vertical": (7, 3),  # same, rotated for a wide/short poster slot
+}
+
+# Adjusts size of ax with colorbar to remain square. Call in-figure with
+# fig.colorbar(fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD) and
+# FIGSIZE["square_scatter_with_colorbar"]
+COLORBAR_FRACTION = 0.25
+COLORBAR_PAD = 0.05
+FIGSIZE["square_scatter_with_colorbar"] = (
+    FIGSIZE["square_scatter"][0] / (1 - COLORBAR_FRACTION - COLORBAR_PAD),
+    FIGSIZE["square_scatter"][1],
+)
+
+# CITE-seq CellType2 annotation values, fixed here so a given cell type always gets
+# the same color everywhere it's plotted
 CELL_TYPES = [
     "ASDC",
     "B intermediate",
@@ -109,28 +124,17 @@ CELL_TYPES = [
     "pDC",
 ]
 
-FIGSIZE = {
-    "single_panel": (5, 3),  # single 1D histogram/line panel
-    "square_scatter": (4, 4),  # single square scatter panel
-    "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
-    "square_heatmap": (6, 6),  # single square heatmap panel with colorbar
-    "alluvial_flow": (3, 7),  # category-transition alluvial (scan_kxstar_bounds.qmd)
-    "alluvial_flow_vertical": (7, 3),  # same, rotated for a wide/short poster slot
-}
-
-# fig.colorbar(mappable, ax=ax) shrinks the given ax to make room for the colorbar rather than
-# growing the canvas, so a panel drawn at FIGSIZE["square_scatter"] with a colorbar attached ends
-# up narrower than intended. Pass these explicitly to fig.colorbar() (fraction=COLORBAR_FRACTION,
-# pad=COLORBAR_PAD) together with FIGSIZE["square_scatter_with_colorbar"], which is derived from
-# square_scatter so the two stay in sync if that base size ever changes.
-COLORBAR_FRACTION = 0.25
-COLORBAR_PAD = 0.05
-FIGSIZE["square_scatter_with_colorbar"] = (
-    FIGSIZE["square_scatter"][0] / (1 - COLORBAR_FRACTION - COLORBAR_PAD),
-    FIGSIZE["square_scatter"][1],
+# Canonical cell-type -> color mapping, built once from the fixed CELL_TYPES list above.
+CELL_TYPE_COLORS = dict(
+    zip(
+        CELL_TYPES,
+        discrete_categorical_colors(len(CELL_TYPES), ["tab10", "tab20", "tab20b"]),
+        strict=True,
+    )
 )
 
 
+## Helper functions
 def gridspec_marginal_spacing(
     fig_width: float,
     fig_height: float,
@@ -217,16 +221,6 @@ def discrete_categorical_colors(n: int, cmap_names: list[str]) -> list:
         f"Only {len(colors)} discrete colors available across {cmap_names}, need {n}"
     )
     return colors[:n]
-
-
-# Canonical cell-type -> color mapping, built once from the fixed CELL_TYPES list above.
-CELL_TYPE_COLORS = dict(
-    zip(
-        CELL_TYPES,
-        discrete_categorical_colors(len(CELL_TYPES), ["tab10", "tab20", "tab20b"]),
-        strict=True,
-    )
-)
 
 
 def standalone_legend_figure(

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -13,6 +13,7 @@ LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
     2.5  # emphasizes summary/aggregate overlays (e.g. "All off-target")
 )
+POINT_SIZE_XS = 7 # extra small scatter points (scatters containing entire scan)
 POINT_SIZE_BACKGROUND = 15  # bulk / non-emphasized scatter points
 POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star markers)
 GRID_ALPHA = 0.3
@@ -56,6 +57,18 @@ FIGSIZE = {
     "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
     "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
 }
+
+# fig.colorbar(mappable, ax=ax) shrinks the given ax to make room for the colorbar rather than
+# growing the canvas, so a panel drawn at FIGSIZE["square_scatter"] with a colorbar attached ends
+# up narrower than intended. Pass these explicitly to fig.colorbar() (fraction=COLORBAR_FRACTION,
+# pad=COLORBAR_PAD) together with FIGSIZE["square_scatter_with_colorbar"], which is derived from
+# square_scatter so the two stay in sync if that base size ever changes.
+COLORBAR_FRACTION = 0.15
+COLORBAR_PAD = 0.05
+FIGSIZE["square_scatter_with_colorbar"] = (
+    FIGSIZE["square_scatter"][0] / (1 - COLORBAR_FRACTION - COLORBAR_PAD),
+    FIGSIZE["square_scatter"][1],
+)
 
 
 def gridspec_marginal_spacing(

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -13,6 +13,8 @@ LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
     2.5  # emphasizes summary/aggregate overlays (e.g. "All off-target")
 )
+POINT_SIZE_BACKGROUND = 15  # bulk / non-emphasized scatter points
+POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star markers)
 GRID_ALPHA = 0.3
 GRID_LINESTYLE = "--"
 LEGEND_FRAMEALPHA = 0.8
@@ -39,8 +41,8 @@ CMAPS = {
 }
 
 FIGSIZE = {
-    "single_panel": (5, 3),  # single 1D histogram/line panel
-    "square_scatter": (5, 5),  # single square scatter panel
+    "single_panel": (4, 3),  # single 1D histogram/line panel
+    "square_scatter": (4, 4),  # single square scatter panel
     "joint_grid": (10, 8),  # 2D joint distribution + marginal histograms
     "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
 }

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -23,6 +23,9 @@ COLORS = {
     "aggregate": "darkred",  # summary overlay across a group (e.g. "All off-target")
     "improved": "#2774AE",  # 2D metric >= 1D metric (pairing helps); anchor color
     "declined": "#C0392B",  # 2D metric < 1D metric (pairing hurts)
+    "Treg": "#28aae2",
+    "CD8 T": "#fbb040",
+    "NK": "#f69792",
 }
 
 LINESTYLES = {

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -1,13 +1,12 @@
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
 
 FONT_FAMILY = "serif"
 FONT_NAME = "Times New Roman"  # matches manuscript mainfont in _quarto.yml
 
 FONT_SIZE_TITLE = 14
-FONT_SIZE_LABEL = 18
-FONT_SIZE_TICK = 14
-FONT_SIZE_LEGEND = 14
-FONT_SIZE_ANNOT = 14  # in-plot data annotations (heatmap cell labels, point/bar labels)
+
+DEFAULT_N_TICKS = 6  # default tick count per axis; override per-plot via set_tick_count
 
 LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
@@ -145,6 +144,25 @@ def gridspec_marginal_spacing(
     hspace = space_for_gap(gap_inches, fig_height, tot_height, n_rows)
     wspace = space_for_gap(gap_inches, fig_width, tot_width, n_cols)
     return hspace, wspace
+
+
+def set_tick_count(
+    ax,
+    n_x: int | None = DEFAULT_N_TICKS,
+    n_y: int | None = DEFAULT_N_TICKS,
+) -> None:
+    """
+    Caps the number of ticks on each axis via MaxNLocator, which rounds to "nice"
+    values (1, 2, 5, 10, ...) rather than forcing an exact count.
+
+    :param ax: Axes to apply tick locators to
+    :param n_x: Max ticks on the x-axis, or None to leave matplotlib's default
+    :param n_y: Max ticks on the y-axis, or None to leave matplotlib's default
+    """
+    if n_x is not None:
+        ax.xaxis.set_major_locator(MaxNLocator(nbins=n_x))
+    if n_y is not None:
+        ax.yaxis.set_major_locator(MaxNLocator(nbins=n_y))
 
 
 def categorical_colors(n: int, cmap_name: str = CMAPS["categorical"]) -> list:

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -4,10 +4,10 @@ FONT_FAMILY = "serif"
 FONT_NAME = "Times New Roman"  # matches manuscript mainfont in _quarto.yml
 
 FONT_SIZE_TITLE = 14
-FONT_SIZE_LABEL = 12
-FONT_SIZE_TICK = 10
-FONT_SIZE_LEGEND = 10
-FONT_SIZE_ANNOT = 10  # in-plot data annotations (heatmap cell labels, point/bar labels)
+FONT_SIZE_LABEL = 18
+FONT_SIZE_TICK = 14
+FONT_SIZE_LEGEND = 14
+FONT_SIZE_ANNOT = 14  # in-plot data annotations (heatmap cell labels, point/bar labels)
 
 LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
@@ -23,9 +23,9 @@ COLORS = {
     "aggregate": "darkred",  # summary overlay across a group (e.g. "All off-target")
     "improved": "#2774AE",  # 2D metric >= 1D metric (pairing helps); anchor color
     "declined": "#C0392B",  # 2D metric < 1D metric (pairing hurts)
-    "Treg": "#28aae2",
-    "CD8 T": "#fbb040",
-    "NK": "#f69792",
+    "Treg": "#1e75bc",
+    "CD8 T": "#f7941d",
+    "NK": "#f0554f",
 }
 
 LINESTYLES = {
@@ -40,7 +40,7 @@ CMAPS = {
 
 FIGSIZE = {
     "single_panel": (5, 3),  # single 1D histogram/line panel
-    "square_scatter": (7, 7),  # single square scatter panel
+    "square_scatter": (5, 5),  # single square scatter panel
     "joint_grid": (10, 8),  # 2D joint distribution + marginal histograms
     "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
 }

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -5,13 +5,13 @@ FONT_FAMILY = "sans-serif"
 FONT_NAME = "Myriad Pro"  # temporary override for comparison; manuscript mainfont in
 # _quarto.yml is still Times New Roman, so figures are out of sync with body text for now
 
-FONT_SIZE_TITLE = 14
+FONT_SIZE_TITLE = 22
 FONT_SIZE_LABEL = 22
 FONT_SIZE_TICK = 20
 FONT_SIZE_LEGEND = 18
 FONT_SIZE_ANNOT = 16  # in-plot data annotations (heatmap cell labels, point/bar labels)
 
-DEFAULT_N_TICKS = 6  # default tick count per axis; override per-plot via set_tick_count
+DEFAULT_N_TICKS = 4  # default tick count per axis; override per-plot via set_tick_count
 
 LINE_WIDTH = 1.5
 LINE_WIDTH_AGGREGATE = (
@@ -44,6 +44,17 @@ COLORS = {
     "outlier_both": "#E63946",  # scan_outliers.qmd: high on both metrics
     "outlier_user": "#9B5DE5",  # scan_outliers.qmd: user-specified pairs
 }
+
+# Shared palette for "two binary conditions crossed" categorical breakdowns (4 categories:
+# neither, condition A only, condition B only, both) — used by scan_outliers.qmd's outlier
+# categories (COLORS["outlier_*"] above) and by the co-pinning / selectivity-gain flow
+# diagrams in scan_kxstar_bounds.qmd, which share the same category shape.
+CROSSED_CONDITION_COLORS = [
+    COLORS["outlier_neither"],
+    COLORS["outlier_metric1"],
+    COLORS["outlier_metric2"],
+    COLORS["outlier_both"],
+]
 
 LINESTYLES = {
     "aggregate": "--",  # dashed, distinguishes summary overlays from individual series
@@ -102,7 +113,9 @@ FIGSIZE = {
     "single_panel": (5, 3),  # single 1D histogram/line panel
     "square_scatter": (4, 4),  # single square scatter panel
     "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
-    "square_heatmap": (5, 5),  # single square heatmap panel with colorbar
+    "square_heatmap": (6, 6),  # single square heatmap panel with colorbar
+    "alluvial_flow": (3, 7),  # category-transition alluvial (scan_kxstar_bounds.qmd)
+    "alluvial_flow_vertical": (7, 3),  # same, rotated for a wide/short poster slot
 }
 
 # fig.colorbar(mappable, ax=ax) shrinks the given ax to make room for the colorbar rather than
@@ -210,7 +223,7 @@ def discrete_categorical_colors(n: int, cmap_names: list[str]) -> list:
 CELL_TYPE_COLORS = dict(
     zip(
         CELL_TYPES,
-        discrete_categorical_colors(len(CELL_TYPES), ["tab20", "tab20b", "tab20c"]),
+        discrete_categorical_colors(len(CELL_TYPES), ["tab10", "tab20", "tab20b"]),
         strict=True,
     )
 )

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -33,6 +33,11 @@ COLORS = {
     "Treg": "#1e75bc",
     "CD8 T": "#f7941d",
     "NK": "#f0554f",
+    "outlier_neither": "lightgray",  # scan_outliers.qmd: neither metric is high
+    "outlier_metric1": "#3A86FF",  # scan_outliers.qmd: metric 1 outlier
+    "outlier_metric2": "#FF9F1C",  # scan_outliers.qmd: metric 2 outlier
+    "outlier_both": "#E63946",  # scan_outliers.qmd: high on both metrics
+    "outlier_user": "#9B5DE5",  # scan_outliers.qmd: user-specified pairs
 }
 
 LINESTYLES = {
@@ -48,7 +53,7 @@ CMAPS = {
 FIGSIZE = {
     "single_panel": (4, 3),  # single 1D histogram/line panel
     "square_scatter": (4, 4),  # single square scatter panel
-    "joint_grid": (10, 8),  # 2D joint distribution + marginal histograms
+    "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
     "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
 }
 
@@ -97,6 +102,39 @@ def categorical_colors(n: int, cmap_name: str = CMAPS["categorical"]) -> list:
     """
     cmap = plt.colormaps.get_cmap(cmap_name).resampled(n)
     return [cmap(i) for i in range(n)]
+
+
+def standalone_legend_figure(handles: list, labels: list[str], **legend_kwargs):
+    """
+    Builds a Figure containing only a legend (its Axes hidden, not removed),
+    sized to exactly the legend's own rendered extent.
+
+    For layouts where one legend is shared across several subpanels rather than
+    repeated in each (so it can be positioned independently, e.g. in Illustrator).
+
+    Two implementation notes, both load-bearing:
+    - The crop is done by resizing the Figure itself, not via
+      `savefig(bbox_inches="tight")`: Quarto/Jupyter's inline display capture only
+      reads `InlineBackend.print_figure_kwargs` once at kernel startup, so a
+      mid-notebook `%config` change to request a tight bbox never takes effect.
+    - The Axes is hidden (`set_axis_off`), not omitted: IPython's figure display
+      silently produces no output at all for a Figure with zero Axes and zero
+      Figure-level lines, so at least one (even if invisible) Axes must remain.
+
+    :param handles: legend handles (e.g. Line2D proxies), one per category
+    :param labels: legend label text, matched positionally to handles
+    :param legend_kwargs: forwarded to Axes.legend (e.g. title, ncol)
+    :return: Figure containing only the legend, resized to its content
+    """
+    fig, ax = plt.subplots()
+    ax.set_axis_off()
+    ax.set_position([0, 0, 1, 1])
+    legend = ax.legend(handles=handles, labels=labels, loc="center", **legend_kwargs)
+    fig.canvas.draw()  # force a render pass so the legend's extent is known
+    bbox = legend.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
+    fig.set_size_inches(bbox.width, bbox.height)
+    ax.set_position([0, 0, 1, 1])  # re-fill the resized canvas; recenters the legend
+    return fig
 
 
 def apply_style() -> None:

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -193,7 +193,9 @@ CELL_TYPE_COLORS = dict(
 )
 
 
-def standalone_legend_figure(handles: list, labels: list[str], **legend_kwargs):
+def standalone_legend_figure(
+    handles: list, labels: list[str], ncol: int = 1, **legend_kwargs
+):
     """
     Builds a Figure containing only a legend (its Axes hidden, not removed),
     sized to exactly the legend's own rendered extent.
@@ -212,13 +214,18 @@ def standalone_legend_figure(handles: list, labels: list[str], **legend_kwargs):
 
     :param handles: legend handles (e.g. Line2D proxies), one per category
     :param labels: legend label text, matched positionally to handles
-    :param legend_kwargs: forwarded to Axes.legend (e.g. title, ncol)
+    :param ncol: number of columns to arrange entries into (matplotlib fills
+        columns top-to-bottom, so row count follows as ceil(len(handles) / ncol));
+        default 1 keeps the original single-column layout
+    :param legend_kwargs: forwarded to Axes.legend (e.g. title)
     :return: Figure containing only the legend, resized to its content
     """
     fig, ax = plt.subplots()
     ax.set_axis_off()
     ax.set_position([0, 0, 1, 1])
-    legend = ax.legend(handles=handles, labels=labels, loc="center", **legend_kwargs)
+    legend = ax.legend(
+        handles=handles, labels=labels, loc="center", ncol=ncol, **legend_kwargs
+    )
     fig.canvas.draw()  # force a render pass so the legend's extent is known
     bbox = legend.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     fig.set_size_inches(bbox.width, bbox.height)

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -98,7 +98,7 @@ FIGSIZE = {
     "single_panel": (4, 3),  # single 1D histogram/line panel
     "square_scatter": (4, 4),  # single square scatter panel
     "joint_grid": (5, 4),  # 2D joint distribution + marginal histograms
-    "square_heatmap": (8, 8),  # single square heatmap panel with colorbar
+    "square_heatmap": (5, 5),  # single square heatmap panel with colorbar
 }
 
 # fig.colorbar(mappable, ax=ax) shrinks the given ax to make room for the colorbar rather than
@@ -106,7 +106,7 @@ FIGSIZE = {
 # up narrower than intended. Pass these explicitly to fig.colorbar() (fraction=COLORBAR_FRACTION,
 # pad=COLORBAR_PAD) together with FIGSIZE["square_scatter_with_colorbar"], which is derived from
 # square_scatter so the two stay in sync if that base size ever changes.
-COLORBAR_FRACTION = 0.15
+COLORBAR_FRACTION = 0.25
 COLORBAR_PAD = 0.05
 FIGSIZE["square_scatter_with_colorbar"] = (
     FIGSIZE["square_scatter"][0] / (1 - COLORBAR_FRACTION - COLORBAR_PAD),

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -52,7 +52,7 @@ COLORS = {
 }
 
 # Shared palette for "two binary conditions crossed" categorical breakdowns, used by
-# scan_outliers.qmd and scan_kxstar_bounds.qmd
+# scan_outliers.qmd and scan_alluvial_flows.qmd
 CROSSED_CONDITION_COLORS = [
     COLORS["outlier_neither"],
     COLORS["outlier_metric1"],
@@ -74,8 +74,10 @@ FIGSIZE = {
         4,
     ),  # 2D joint distribution + marginal histograms (raw_2D-hist.qmd)
     "square_heatmap": (6, 6),  # large square panel (heatmaps, etc.)
-    "alluvial_flow": (3, 7),  # category-transition alluvial (scan_kxstar_bounds.qmd)
-    "alluvial_flow_vertical": (7, 3),  # same, rotated for a wide/short poster slot
+    "alluvial_flow": (
+        7,
+        3,
+    ),  # category-transition alluvial, source-top/destination-bottom (scan_alluvial_flows.qmd)
 }
 
 # Adjusts size of ax with colorbar to remain square. Call in-figure with
@@ -123,15 +125,6 @@ CELL_TYPES = [
     "gdT",
     "pDC",
 ]
-
-# Canonical cell-type -> color mapping, built once from the fixed CELL_TYPES list above.
-CELL_TYPE_COLORS = dict(
-    zip(
-        CELL_TYPES,
-        discrete_categorical_colors(len(CELL_TYPES), ["tab10", "tab20", "tab20b"]),
-        strict=True,
-    )
-)
 
 
 ## Helper functions
@@ -221,6 +214,15 @@ def discrete_categorical_colors(n: int, cmap_names: list[str]) -> list:
         f"Only {len(colors)} discrete colors available across {cmap_names}, need {n}"
     )
     return colors[:n]
+
+# Canonical cell-type -> color mapping, built once from the fixed CELL_TYPES list above.
+CELL_TYPE_COLORS = dict(
+    zip(
+        CELL_TYPES,
+        discrete_categorical_colors(len(CELL_TYPES), ["tab10", "tab20", "tab20b"]),
+        strict=True,
+    )
+)
 
 
 def standalone_legend_figure(

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -46,6 +46,39 @@ FIGSIZE = {
 }
 
 
+def gridspec_marginal_spacing(
+    fig_width: float,
+    fig_height: float,
+    grid_bounds: tuple[float, float, float, float],
+    n_rows: int,
+    n_cols: int,
+    gap_inches: float,
+) -> tuple[float, float]:
+    """
+    Returns (hspace, wspace) for a 2D-joint-plus-marginals GridSpec such that
+    the physical gap between the main panel and each marginal is the same in
+    both directions. Matplotlib's hspace/wspace are fractions of the average
+    row/column size, not of a shared physical unit, so equal hspace/wspace
+    values (or a square figure's worth of intuition) produce visibly unequal
+    gaps whenever the figure or the grid's row/column ratios aren't square.
+
+    :param grid_bounds: (left, right, top, bottom) figure-fraction bounds passed to GridSpec
+    :param gap_inches: desired physical gap between the main panel and each marginal
+    :return: (hspace, wspace) to pass to GridSpec
+    """
+    left, right, top, bottom = grid_bounds
+    tot_width = right - left
+    tot_height = top - bottom
+
+    def space_for_gap(gap: float, fig_dim: float, tot_frac: float, n: int) -> float:
+        gap_frac = gap / fig_dim
+        return gap_frac * n / (tot_frac - gap_frac * (n - 1))
+
+    hspace = space_for_gap(gap_inches, fig_height, tot_height, n_rows)
+    wspace = space_for_gap(gap_inches, fig_width, tot_width, n_cols)
+    return hspace, wspace
+
+
 def categorical_colors(n: int, cmap_name: str = CMAPS["categorical"]) -> list:
     """
     Returns n distinct qualitative colors for identifying arbitrary subgroups

--- a/bicytok/figure_styles.py
+++ b/bicytok/figure_styles.py
@@ -18,6 +18,11 @@ POINT_SIZE_FOREGROUND = 30  # highlighted points (outliers, top hits, star marke
 GRID_ALPHA = 0.3
 GRID_LINESTYLE = "--"
 LEGEND_FRAMEALPHA = 0.8
+LEGEND_BORDERPAD = 0.3  # padding between legend border and its content (default 0.4)
+LEGEND_LABELSPACING = 0.3  # vertical space between entries (default 0.5)
+LEGEND_HANDLELENGTH = 1.5  # length of the marker/line handle sample (default 2.0)
+LEGEND_HANDLETEXTPAD = 0.5  # space between handle and label text (default 0.8)
+LEGEND_BORDERAXESPAD = 0.3  # space between legend and axes edge (default 0.5)
 
 COLORS = {
     "target": "#CF4D6F",  # as currently used in raw_1D-hist.qmd
@@ -111,6 +116,11 @@ def apply_style() -> None:
             "legend.fontsize": FONT_SIZE_LEGEND,
             "legend.title_fontsize": FONT_SIZE_LEGEND,
             "legend.framealpha": LEGEND_FRAMEALPHA,
+            "legend.borderpad": LEGEND_BORDERPAD,
+            "legend.labelspacing": LEGEND_LABELSPACING,
+            "legend.handlelength": LEGEND_HANDLELENGTH,
+            "legend.handletextpad": LEGEND_HANDLETEXTPAD,
+            "legend.borderaxespad": LEGEND_BORDERAXESPAD,
             "lines.linewidth": LINE_WIDTH,
             "axes.grid": True,
             "grid.alpha": GRID_ALPHA,

--- a/bicytok/scan_runners.py
+++ b/bicytok/scan_runners.py
@@ -10,12 +10,12 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from bicytok.imports import (
+from .imports import (
     importCITE,
     match_receptor_abundances,
     sample_prototype_signal_receptor,
 )
-from bicytok.scanning_funcs import sample_cells, scan_KL_EMD, scan_selectivity
+from .scanning_funcs import sample_cells, scan_KL_EMD, scan_selectivity
 
 
 def run_selectivity_scan():

--- a/bicytok/test/test_scanning_functions.py
+++ b/bicytok/test/test_scanning_functions.py
@@ -8,14 +8,13 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from figures.scanning_analyses.scan_runners import (
+from ..imports import sample_test_data as sample_data
+from ..scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
     run_KL_EMD_scan,
     run_selectivity_scan,
 )
-
-from ..imports import sample_test_data as sample_data
 from ..scanning_funcs import scan_KL_EMD, scan_selectivity
 
 
@@ -244,7 +243,7 @@ def test_runner_loader_roundtrip(tmp_path):
     #   outputs. This bypasses the expensive scanning optimizations.
     with (
         patch(
-            "figures.scanning_analyses.scan_runners.scan_selectivity",
+            "bicytok.scan_runners.scan_selectivity",
             side_effect=mock_scan_selectivity,
         ),
         patch("sys.argv", ["selectivity_scan", "--output-path", selec_path]),
@@ -276,7 +275,7 @@ def test_runner_loader_roundtrip(tmp_path):
     kl_emd_path = str(tmp_path / "kl_emd_scan.csv")
     with (
         patch(
-            "figures.scanning_analyses.scan_runners.scan_KL_EMD",
+            "bicytok.scan_runners.scan_KL_EMD",
             side_effect=mock_scan_KL_EMD,
         ),
         patch("sys.argv", ["KL_EMD_scan", "--output-path", kl_emd_path]),

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -27,19 +27,19 @@ Visualizes receptor expression distributions with each off-target cell populatio
 ```{python}
 #| fig-cap: "1D receptor distribution colored by off-target population"
 %config InlineBackend.figure_formats = ['svg']
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 
+from bicytok.figure_styles import COLORS, FIGSIZE, apply_style, categorical_colors
 from bicytok.imports import importCITE, sample_receptor_abundances
 
-plt.rcParams["svg.fonttype"] = "none"
+apply_style()
 
 # Parameters
 receptor = "CD25"
 targ_cell = "Treg"
-off_targ_cell_types = ["CD4 TEM", "CD4 TCM", "CD8 Proliferating", "dnT", "ILC"]
+off_targ_cell_types = ["NK", "CD8 TCM"]
 sample_size = 5000
 cell_categorization = "CellType2"
 stat = "probability"
@@ -47,11 +47,8 @@ normalize = False
 x_lim = True
 
 # Color scheme: target is fixed, off-target populations get distinct colors
-TARGET_COLOR = "#CF4D6F"
-off_targ_palette = matplotlib.colormaps.get_cmap("tab10").resampled(
-    len(off_targ_cell_types)
-)
-off_targ_colors = [off_targ_palette(i) for i in range(len(off_targ_cell_types))]
+TARGET_COLOR = COLORS["target"]
+off_targ_colors = categorical_colors(len(off_targ_cell_types))
 
 # Load and prepare data
 CITE_DF, cell_types = importCITE(cell_categorization)
@@ -93,7 +90,7 @@ for cell_type in populations:
         vals = vals / mean_abundance
     all_cell_abundances.append(vals)
 
-fig, ax = plt.subplots(figsize=(6, 4))
+fig, ax = plt.subplots(figsize=FIGSIZE["single_panel"])
 
 for _, (abundances, color, label) in enumerate(
     zip(all_cell_abundances, colors, labels, strict=False)
@@ -117,7 +114,7 @@ all_off_targ = np.concatenate([ab for ab in all_cell_abundances[1:] if len(ab) >
 if len(all_off_targ) > 0:
     sns.histplot(
         all_off_targ,
-        color="darkred",
+        color=COLORS["aggregate"],
         alpha=0,
         edgecolor="none",
         stat=stat,
@@ -128,27 +125,25 @@ if len(all_off_targ) > 0:
         label="All off-target",
     )
 
-ax.set_title(f"{receptor} Distribution by Cell Type", fontsize=12)
+ax.set_title(f"{receptor} Distribution by Cell Type")
 
 if normalize:
-    ax.set_xlabel("Normalized receptor count", fontsize=14)
+    ax.set_xlabel("Normalized receptor count")
 else:
-    ax.set_xlabel(f"Number of {receptor} Antibodies", fontsize=14)
+    ax.set_xlabel(f"Number of {receptor} Antibodies")
 
 if stat == "density":
-    ax.set_ylabel("Density", fontsize=14)
+    ax.set_ylabel("Density")
 elif stat == "count":
-    ax.set_ylabel("Number of Cells", fontsize=14)
+    ax.set_ylabel("Number of Cells")
 elif stat == "probability":
-    ax.set_ylabel("Proportion of cells", fontsize=14)
+    ax.set_ylabel("Proportion of cells")
 
 if x_lim:
     x_max = np.percentile(rec_abundance, 99) * 1.1
     ax.set_xlim(0, x_max)
 
-ax.tick_params(axis="both", labelsize=12)
-ax.legend(loc="upper right", fontsize=10, framealpha=0.8)
-ax.grid(alpha=0.3, linestyle="--")
+ax.legend(loc="upper right")
 plt.tight_layout()
 plt.show()
 ```
@@ -159,16 +154,24 @@ plt.show()
 #| label: fig-raw-celltype-hist
 #| fig-cap: "2D distribution with marginal projections colored by off-target population"
 %config InlineBackend.figure_formats = ['svg']
-import matplotlib
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
 
+from bicytok.figure_styles import (
+    COLORS,
+    FIGSIZE,
+    FONT_SIZE_TITLE,
+    LINE_WIDTH_AGGREGATE,
+    LINESTYLES,
+    apply_style,
+    categorical_colors,
+)
 from bicytok.imports import importCITE, sample_receptor_abundances
 
-plt.rcParams["svg.fonttype"] = "none"
+apply_style()
 
 # Parameters
 receptor1 = "CD45RO"
@@ -179,16 +182,11 @@ sample_size = 2500
 cell_categorization = "CellType2"
 normalize = False
 
-# Figure layout
-FIGURE_SIZE = (10, 8)
 DPI = 100
 
 # Color scheme
-TARGET_COLOR = "#CF4D6F"
-off_targ_palette = matplotlib.colormaps.get_cmap("tab10").resampled(
-    len(off_targ_cell_types)
-)
-off_targ_colors = [off_targ_palette(i) for i in range(len(off_targ_cell_types))]
+TARGET_COLOR = COLORS["target"]
+off_targ_colors = categorical_colors(len(off_targ_cell_types))
 
 populations = [targ_cell] + off_targ_cell_types
 colors = [TARGET_COLOR] + off_targ_colors
@@ -237,7 +235,7 @@ x_max = np.percentile(plot_df[x_col], 99) * 1.1
 y_max = np.percentile(plot_df[y_col], 99) * 1.1
 x_min = y_min = 0
 
-fig = plt.figure(figsize=FIGURE_SIZE, dpi=DPI)
+fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
 gs = gridspec.GridSpec(
     3,
     3,
@@ -302,62 +300,64 @@ if len(off_targ_df) > 10:
     sns.kdeplot(
         x=off_targ_df[x_col],
         y=off_targ_df[y_col],
-        color="darkred",
+        color=COLORS["aggregate"],
         levels=4,
-        linewidths=2,
-        linestyles="--",
+        linewidths=LINE_WIDTH_AGGREGATE,
+        linestyles=LINESTYLES["aggregate"],
         ax=ax_main,
         label="All off-target",
     )
     sns.histplot(
         off_targ_df[x_col].values,
-        color="darkred",
+        color=COLORS["aggregate"],
         alpha=0,
         edgecolor="none",
         bins=30,
         kde=True,
         kde_kws={"bw_method": "scott"},
-        line_kws={"linestyle": "--", "linewidth": 2.5},
+        line_kws={
+            "linestyle": LINESTYLES["aggregate"],
+            "linewidth": LINE_WIDTH_AGGREGATE,
+        },
         ax=ax_top,
     )
     sns.histplot(
         y=off_targ_df[y_col].values,
-        color="darkred",
+        color=COLORS["aggregate"],
         alpha=0,
         edgecolor="none",
         bins=30,
         kde=True,
         kde_kws={"bw_method": "scott"},
-        line_kws={"linestyle": "--", "linewidth": 2.5},
+        line_kws={
+            "linestyle": LINESTYLES["aggregate"],
+            "linewidth": LINE_WIDTH_AGGREGATE,
+        },
         ax=ax_right,
     )
 
 # Main panel formatting
 ax_main.set_xlim(x_min, x_max)
 ax_main.set_ylim(y_min, y_max)
-ax_main.grid(alpha=0.3, linestyle="--")
 xlabel = f"{receptor1} Normalized Count" if normalize else f"{receptor1} Count"
 ylabel = f"{receptor2} Normalized Count" if normalize else f"{receptor2} Count"
-ax_main.set_xlabel(xlabel, fontsize=14)
-ax_main.set_ylabel(ylabel, fontsize=14)
-ax_main.tick_params(axis="both", labelsize=12)
-ax_main.legend(fontsize=10, framealpha=0.8, markerscale=2)
+ax_main.set_xlabel(xlabel)
+ax_main.set_ylabel(ylabel)
+ax_main.legend(markerscale=2)
 
 # Top marginal formatting
 ax_top.set_xlim(x_min, x_max)
-ax_top.set_ylabel("Cells", fontsize=12)
-ax_top.tick_params(axis="both", labelsize=10)
+ax_top.set_ylabel("Cells")
 plt.setp(ax_top.get_xticklabels(), visible=False)
 
 # Right marginal formatting
 ax_right.set_ylim(y_min, y_max)
-ax_right.set_xlabel("Cells", fontsize=12)
-ax_right.tick_params(axis="both", labelsize=10)
+ax_right.set_xlabel("Cells")
 plt.setp(ax_right.get_yticklabels(), visible=False)
 
 fig.suptitle(
     f"{receptor1} vs {receptor2} — Off-target Population Breakdown",
-    fontsize=14,
+    fontsize=FONT_SIZE_TITLE,
     y=0.98,
 )
 

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -178,6 +178,7 @@ from bicytok.figure_styles import (
     FIGSIZE,
     LINE_WIDTH_AGGREGATE,
     LINESTYLES,
+    POINT_SIZE_BACKGROUND,
     apply_style,
     categorical_colors,
     gridspec_marginal_spacing,
@@ -289,7 +290,7 @@ for cell_type, color, label in zip(populations, colors, labels, strict=False):
         cell_df[y_col],
         alpha=0.3,
         color=color,
-        s=8,
+        s=POINT_SIZE_BACKGROUND,
         label=label,
     )
     if len(cell_df) > 10:

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -133,10 +133,17 @@ if not hide_aggregate_KDE:
             label="All off-target",
         )
 
+if receptor == "CD122":
+    rec_label = "IL-2Rβ"
+elif receptor == "CD25":
+    rec_label = "IL-2Rα"
+else:
+    rec_label = receptor
+
 if normalize:
     ax.set_xlabel("Normalized receptor count")
 else:
-    ax.set_xlabel(f"Number of {receptor} Antibodies")
+    ax.set_xlabel(f"Number of {rec_label} Antibodies")
 
 if stat == "density":
     ax.set_ylabel("Density")

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -45,6 +45,7 @@ cell_categorization = "CellType2"
 stat = "probability"
 normalize = False
 x_lim = True
+hide_aggregate_KDE = False
 
 # Color scheme: target is fixed, off-target populations get distinct colors
 TARGET_COLOR = COLORS["target"]
@@ -110,20 +111,21 @@ for _, (abundances, color, label) in enumerate(
     )
 
 # Overall off-target KDE overlay (dashed, summarizes all off-target populations combined)
-all_off_targ = np.concatenate([ab for ab in all_cell_abundances[1:] if len(ab) > 0])
-if len(all_off_targ) > 0:
-    sns.histplot(
-        all_off_targ,
-        color=COLORS["aggregate"],
-        alpha=0,
-        edgecolor="none",
-        stat=stat,
-        bins=30,
-        kde=True,
-        kde_kws={"bw_method": "scott"},
-        ax=ax,
-        label="All off-target",
-    )
+if not hide_aggregate_KDE:
+    all_off_targ = np.concatenate([ab for ab in all_cell_abundances[1:] if len(ab) > 0])
+    if len(all_off_targ) > 0:
+        sns.histplot(
+            all_off_targ,
+            color=COLORS["aggregate"],
+            alpha=0,
+            edgecolor="none",
+            stat=stat,
+            bins=30,
+            kde=True,
+            kde_kws={"bw_method": "scott"},
+            ax=ax,
+            label="All off-target",
+        )
 
 ax.set_title(f"{receptor} Distribution by Cell Type")
 

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -31,7 +31,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 
-from bicytok.figure_styles import COLORS, FIGSIZE, apply_style, categorical_colors
+from bicytok.figure_styles import (
+    COLORS,
+    FIGSIZE,
+    apply_style,
+    categorical_colors,
+    set_tick_count,
+)
 from bicytok.imports import importCITE, sample_receptor_abundances
 
 apply_style()
@@ -143,18 +149,20 @@ else:
 if normalize:
     ax.set_xlabel("Normalized receptor count")
 else:
-    ax.set_xlabel(f"Number of {rec_label} Antibodies")
+    ax.set_xlabel(f"{rec_label} Count")
 
 if stat == "density":
     ax.set_ylabel("Density")
 elif stat == "count":
     ax.set_ylabel("Number of Cells")
 elif stat == "probability":
-    ax.set_ylabel("Proportion of cells")
+    ax.set_ylabel("Cell Fraction")
 
 if x_lim:
     x_max = np.percentile(rec_abundance, 99) * 1.1
     ax.set_xlim(0, x_max)
+
+set_tick_count(ax, n_x=4, n_y=3)
 
 ax.legend(loc="upper right")
 plt.tight_layout()

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -149,12 +149,12 @@ else:
 if normalize:
     ax.set_xlabel("Normalized receptor count")
 else:
-    ax.set_xlabel(f"{rec_label} Count")
+    ax.set_xlabel(f"{rec_label} ADT Count")
 
 if stat == "density":
     ax.set_ylabel("Density")
 elif stat == "count":
-    ax.set_ylabel("Number of Cells")
+    ax.set_ylabel("Cell Count")
 elif stat == "probability":
     ax.set_ylabel("Cell Fraction")
 
@@ -391,17 +391,4 @@ ax_right.set_xlabel("Cells")
 plt.setp(ax_right.get_yticklabels(), visible=False)
 
 plt.show()
-```
-
-## Parameter Summary
-```{python}
-#| output: asis
-text = f"""
-**1D analysis**: receptor **{receptor}**, target **{targ_cell}**, off-target populations: {", ".join(f"**{c}**" for c in off_targ_cell_types)}.
-
-**2D analysis**: receptors **{receptor1}** × **{receptor2}**, target **{targ_cell}**, off-target populations: {", ".join(f"**{c}**" for c in off_targ_cell_types)}.
-
-Sample size: **{sample_size}** cells per analysis. Receptor counts were {"**normalized**" if normalize else "**not normalized**"}.
-"""
-print(text)
 ```

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -45,7 +45,7 @@ cell_categorization = "CellType2"
 stat = "probability"
 normalize = False
 x_lim = True
-hide_aggregate_KDE = False
+hide_aggregate_KDE = True
 Treg_eg = True # Use this if showing expression in Tregs, CD8 TCM, and NK cells
 
 if Treg_eg:
@@ -132,8 +132,6 @@ if not hide_aggregate_KDE:
             ax=ax,
             label="All off-target",
         )
-
-ax.set_title(f"{receptor} Distribution by Cell Type")
 
 if normalize:
     ax.set_xlabel("Normalized receptor count")
@@ -362,12 +360,6 @@ plt.setp(ax_top.get_xticklabels(), visible=False)
 ax_right.set_ylim(y_min, y_max)
 ax_right.set_xlabel("Cells")
 plt.setp(ax_right.get_yticklabels(), visible=False)
-
-fig.suptitle(
-    f"{receptor1} vs {receptor2} — Off-target Population Breakdown",
-    fontsize=FONT_SIZE_TITLE,
-    y=0.98,
-)
 
 plt.show()
 ```

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -46,10 +46,16 @@ stat = "probability"
 normalize = False
 x_lim = True
 hide_aggregate_KDE = False
+Treg_eg = True # Use this if showing expression in Tregs, CD8 TCM, and NK cells
 
-# Color scheme: target is fixed, off-target populations get distinct colors
-TARGET_COLOR = COLORS["target"]
-off_targ_colors = categorical_colors(len(off_targ_cell_types))
+if Treg_eg:
+    # Specified color scheme to match illustrative figure colors
+    TARGET_COLOR = COLORS["Treg"]
+    off_targ_colors = list([COLORS["CD8 T"], COLORS["NK"]])
+else:
+    # General color scheme: target is fixed, off-target populations get distinct colors
+    TARGET_COLOR = COLORS["target"]
+    off_targ_colors = categorical_colors(len(off_targ_cell_types))
 
 # Load and prepare data
 CITE_DF, cell_types = importCITE(cell_categorization)

--- a/figures/raw_distribution_figures/off_targ_breakdown.qmd
+++ b/figures/raw_distribution_figures/off_targ_breakdown.qmd
@@ -46,7 +46,7 @@ stat = "probability"
 normalize = False
 x_lim = True
 hide_aggregate_KDE = True
-Treg_eg = True # Use this if showing expression in Tregs, CD8 TCM, and NK cells
+Treg_eg = True  # Use this if showing expression in Tregs, CD8 TCM, and NK cells
 
 if Treg_eg:
     # Specified color scheme to match illustrative figure colors
@@ -176,11 +176,11 @@ import seaborn as sns
 from bicytok.figure_styles import (
     COLORS,
     FIGSIZE,
-    FONT_SIZE_TITLE,
     LINE_WIDTH_AGGREGATE,
     LINESTYLES,
     apply_style,
     categorical_colors,
+    gridspec_marginal_spacing,
 )
 from bicytok.imports import importCITE, sample_receptor_abundances
 
@@ -248,17 +248,30 @@ x_max = np.percentile(plot_df[x_col], 99) * 1.1
 y_max = np.percentile(plot_df[y_col], 99) * 1.1
 x_min = y_min = 0
 
+GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
+MARGINAL_GAP_IN = 0.25  # physical gap between main panel and each marginal histogram
+
 fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
+hspace, wspace = gridspec_marginal_spacing(
+    fig_width=FIGSIZE["joint_grid"][0],
+    fig_height=FIGSIZE["joint_grid"][1],
+    grid_bounds=GRID_BOUNDS,
+    n_rows=3,
+    n_cols=3,
+    gap_inches=MARGINAL_GAP_IN,
+)
 gs = gridspec.GridSpec(
     3,
     3,
     figure=fig,
     width_ratios=[1, 4, 1],
     height_ratios=[1, 4, 0.2],
-    hspace=0.15,
-    wspace=0.05,
-    top=0.88,
-    bottom=0.1,
+    hspace=hspace,
+    wspace=wspace,
+    left=GRID_BOUNDS[0],
+    right=GRID_BOUNDS[1],
+    top=GRID_BOUNDS[2],
+    bottom=GRID_BOUNDS[3],
 )
 
 ax_main = fig.add_subplot(gs[1, 1])

--- a/figures/raw_distribution_figures/raw_1D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_1D-hist.qmd
@@ -29,13 +29,13 @@ Generates a histogram with kernel density estimation (KDE) overlay to visualize 
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
-import matplotlib.pyplot as plt
 import numpy as np
 
 from bicytok.distance_metric_funcs import KL_EMD_1D
+from bicytok.figure_styles import apply_style
 from bicytok.imports import importCITE, sample_receptor_abundances
 
-plt.rcParams["svg.fonttype"] = "none"
+apply_style()
 
 receptor = "CD27"
 sample_size = 5000
@@ -108,12 +108,13 @@ for cell_type in plot_cell_types:
 ```{python}
 #| label: fig-raw-1d-hist
 #| fig-cap: "1D distribution of receptor with histogram and KDE overlay"
+import matplotlib.pyplot as plt
 import seaborn as sns
 
-fig_size = (5, 3)
+from bicytok.figure_styles import COLORS, FIGSIZE
 
-plt.figure(figsize=fig_size)
-colors = ["#CF4D6F", "#2774AE"]
+plt.figure(figsize=FIGSIZE["single_panel"])
+colors = [COLORS["target"], COLORS["off_target"]]
 for i, abundances in enumerate(all_cell_abundances):
     if len(abundances) == 0:
         continue
@@ -128,27 +129,24 @@ for i, abundances in enumerate(all_cell_abundances):
         edgecolor="black",
     )
 
-plt.title(f"{receptor} Distribution\nKL: {kl_val:.2f}, EMD: {emd_val:.2f}", fontsize=10)
+plt.title(f"{receptor} Distribution\nKL: {kl_val:.2f}, EMD: {emd_val:.2f}")
 if normalize:
-    plt.xlabel("Normalized receptor count", fontsize=18)
+    plt.xlabel("Normalized receptor count")
 else:
-    plt.xlabel(f"Number of {receptor} Antibodies", fontsize=18)
+    plt.xlabel(f"Number of {receptor} Antibodies")
 
 if stat == "density":
-    plt.ylabel("Density", fontsize=18)
+    plt.ylabel("Density")
 elif stat == "count":
-    plt.ylabel("Number of Cells", fontsize=18)
+    plt.ylabel("Number of Cells")
 elif stat == "probability":
-    plt.ylabel("Proportion of cells", fontsize=18)
+    plt.ylabel("Proportion of cells")
 
 if x_limit:
     x_max = np.percentile(targ_abundances, 99.5)
     plt.xlim(0, x_max * 0.6)
 
-plt.tick_params(axis="x", labelsize=15)
-plt.tick_params(axis="y", labelsize=15)
-plt.legend(loc="upper right", fontsize=18)
-plt.grid(alpha=0.3, linestyle="--")
+plt.legend(loc="upper right")
 plt.tight_layout()
 plt.show()
 ```

--- a/figures/raw_distribution_figures/raw_1D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_1D-hist.qmd
@@ -129,7 +129,6 @@ for i, abundances in enumerate(all_cell_abundances):
         edgecolor="black",
     )
 
-plt.title(f"{receptor} Distribution\nKL: {kl_val:.2f}, EMD: {emd_val:.2f}")
 if normalize:
     plt.xlabel("Normalized receptor count")
 else:
@@ -149,6 +148,9 @@ if x_limit:
 plt.legend(loc="upper right")
 plt.tight_layout()
 plt.show()
+
+print(f"KL Divergence: {kl_val:.4f}")
+print(f"EMD: {emd_val:.4f}")
 ```
 
 ## Parameter Summary

--- a/figures/raw_distribution_figures/raw_1D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_1D-hist.qmd
@@ -129,17 +129,24 @@ for i, abundances in enumerate(all_cell_abundances):
         edgecolor="black",
     )
 
+if receptor == "CD122":
+    rec_label = "IL-2Rβ"
+elif receptor == "CD25":
+    rec_label = "IL-2Rα"
+else:
+    rec_label = receptor
+
 if normalize:
     plt.xlabel("Normalized receptor count")
 else:
-    plt.xlabel(f"Number of {receptor} Antibodies")
+    plt.xlabel(f"{rec_label} ADT Count")
 
 if stat == "density":
     plt.ylabel("Density")
 elif stat == "count":
-    plt.ylabel("Number of Cells")
+    plt.ylabel("Cell Count")
 elif stat == "probability":
-    plt.ylabel("Proportion of cells")
+    plt.ylabel("Cell Fraction")
 
 if x_limit:
     x_max = np.percentile(targ_abundances, 99.5)
@@ -151,14 +158,4 @@ plt.show()
 
 print(f"KL Divergence: {kl_val:.4f}")
 print(f"EMD: {emd_val:.4f}")
-```
-
-## Parameter Summary
-```{python}
-#| output: asis
-text = f"""
-Analyzed the distribution of the receptor **{receptor}** between target cell type **{targ_cell}** and all other cell types. The analysis was performed on **{sample_size}** cells sampled from the CITE-seq dataset. The histogram statistic used was '**{stat}**' and the epitope counts were {"**normalized**" if normalize else "**not normalized**"} for comparison
-"""
-
-print(text)
 ```

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -308,16 +308,6 @@ for i, cell_type in enumerate(
 ax_top.set_xlim(x_min, x_max)
 ax_top.set_ylabel("Number of Cells", fontsize=16)
 ax_top.tick_params(axis="both", labelsize=18)
-ax_top.text(
-    0.02,
-    0.95,
-    f"X-axis: KL={kl_val_1:.2f}, EMD={emd_val_1:.2f}\nSelectivity ({signal[0]}+{receptor1}): {selectivity_1d_rec1:.2f}",
-    transform=ax_top.transAxes,
-    fontsize=15,
-    verticalalignment="top",
-    horizontalalignment="left",
-    bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
-)
 plt.setp(ax_top.get_xticklabels(), visible=False)
 
 # Right marginal plot (y-axis projection)
@@ -342,27 +332,14 @@ ax_right.set_xlabel("Number of Cells", fontsize=16)
 ax_right.tick_params(axis="both", labelsize=18)
 plt.setp(ax_right.get_yticklabels(), visible=False)
 
-# Add text annotation for y-axis metrics
-ax_right.text(
-    0.95,
-    0.95,
-    f"Y-axis:\nKL={kl_val_2:.2f}\nEMD={emd_val_2:.2f}\nSelectivity ({signal[0]}+{receptor2}): {selectivity_1d_rec2:.2f}",
-    transform=ax_right.transAxes,
-    fontsize=15,
-    verticalalignment="top",
-    horizontalalignment="right",
-    bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
-)
-
-# Add overall title and 2D metrics
-fig.suptitle(
-    f"{receptor1} vs {receptor2} with Marginal Projections\n"
-    f"2D Metrics - KL: {kl_val_2d:.2f}, EMD: {emd_val_2d:.2f}, Selectivity ({signal[0]}+{receptor1}+{receptor2}): {selectivity_2d:.2f}",
-    fontsize=16,
-    y=0.98,
-)
-
 plt.show()
+
+print(f"X-axis ({receptor1}) KL Divergence: {kl_val_1:.4f}")
+print(f"X-axis ({receptor1}) EMD: {emd_val_1:.4f}")
+print(f"Y-axis ({receptor2}) KL Divergence: {kl_val_2:.4f}")
+print(f"Y-axis ({receptor2}) EMD: {emd_val_2:.4f}")
+print(f"2D ({receptor1}+{receptor2}) KL Divergence: {kl_val_2d:.4f}")
+print(f"2D ({receptor1}+{receptor2}) EMD: {emd_val_2d:.4f}")
 ```
 
 ## Parameter Summary

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -34,26 +34,27 @@ Generates a combined figure showing the 2D receptor distribution in the center w
 %config InlineBackend.figure_formats = ['svg']
 import time
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
 from bicytok.distance_metric_funcs import KL_EMD_1D, KL_EMD_2D
+from bicytok.figure_styles import COLORS, apply_style
 from bicytok.imports import importCITE, sample_receptor_abundances
 from bicytok.selectivity_funcs import optimize_affs
 
-plt.rcParams["svg.fonttype"] = "none"
+apply_style()
 
 # Parameters
-receptor1 = "CD45RO"
-receptor2 = "Integrin-7"
-targ_cell = "CD4 Naive"
+receptor1 = "GP130"
+receptor2 = "CD202b"
+targ_cell = "Treg"
 off_targ_cell_types = None
 sample_size = 2500
 cell_categorization = "CellType2"
 plot_cell_types = [targ_cell, "other"]
 normalize = False
 calc_selec = False
+limit_axes = False  # Set False to let matplotlib auto-scale axes to the full data range
 
 # Selectivity parameters
 dose = 1e-10  # ligand concentration in M
@@ -66,13 +67,12 @@ valencies_2d = np.array(
 )  # valencies for 2D case (signal + two target receptors)
 
 # Color scheme
-TARGET_COLOR = "#CF4D6F"
-OFF_TARGET_COLOR = "#2774AE"
+TARGET_COLOR = COLORS["target"]
+OFF_TARGET_COLOR = COLORS["off_target"]
 colors = [TARGET_COLOR, OFF_TARGET_COLOR]
 cell_type_labels = ["Target", "Off-target"]
 
 # Figure dimensions for marginal plot layout
-FIGURE_SIZE = (10, 8)
 DPI = 100
 
 # Data loading and processing
@@ -221,19 +221,23 @@ plot_df = pd.DataFrame(
 )
 
 # Calculate consistent axis limits for alignment
-x_max = np.percentile(plot_df[f"{receptor1}_norm"], 99) * 1.1
-y_max = np.percentile(plot_df[f"{receptor2}_norm"], 99) * 1.1
-x_min = y_min = 0
+if limit_axes:
+    x_max = np.percentile(plot_df[f"{receptor1}_norm"], 99) * 1.1
+    y_max = np.percentile(plot_df[f"{receptor2}_norm"], 99) * 1.1
+    x_min = y_min = 0
 ```
 
 ```{python}
 #| label: fig-raw-2d-hist
 #| fig-cap: "2D distribution with marginal 1D projections showing axis projections"
 import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
 import seaborn as sns
 
+from bicytok.figure_styles import FIGSIZE
+
 # Create figure with custom gridspec for marginal plots
-fig = plt.figure(figsize=FIGURE_SIZE, dpi=DPI)
+fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
 gs = gridspec.GridSpec(
     3,
     3,
@@ -273,19 +277,18 @@ for i, cell_type in enumerate(
         ax=ax_main,
     )
 
-ax_main.set_xlim(x_min, x_max)
-ax_main.set_ylim(y_min, y_max)
-ax_main.grid(alpha=0.3, linestyle="--")
+if limit_axes:
+    ax_main.set_xlim(x_min, x_max)
+    ax_main.set_ylim(y_min, y_max)
 
 if normalize:
-    ax_main.set_xlabel(f"{receptor1} Normalized Count", fontsize=20)
-    ax_main.set_ylabel(f"{receptor2} Normalized Count", fontsize=20)
+    ax_main.set_xlabel(f"{receptor1} Normalized Count")
+    ax_main.set_ylabel(f"{receptor2} Normalized Count")
 else:
-    ax_main.set_xlabel(f"{receptor1} Count", fontsize=20)
-    ax_main.set_ylabel(f"{receptor2} Count", fontsize=20)
+    ax_main.set_xlabel(f"{receptor1} Count")
+    ax_main.set_ylabel(f"{receptor2} Count")
 
-ax_main.tick_params(axis="both", labelsize=18)
-ax_main.legend(fontsize=20)
+ax_main.legend()
 
 # Top marginal plot (x-axis projection)
 ax_top = fig.add_subplot(gs[0, 1], sharex=ax_main)
@@ -305,9 +308,9 @@ for i, cell_type in enumerate(
         label=cell_type_labels[i],
     )
 
-ax_top.set_xlim(x_min, x_max)
-ax_top.set_ylabel("Number of Cells", fontsize=16)
-ax_top.tick_params(axis="both", labelsize=18)
+if limit_axes:
+    ax_top.set_xlim(x_min, x_max)
+ax_top.set_ylabel("Number of Cells")
 plt.setp(ax_top.get_xticklabels(), visible=False)
 
 # Right marginal plot (y-axis projection)
@@ -327,9 +330,9 @@ for i, cell_type in enumerate(
         ax=ax_right,
     )
 
-ax_right.set_ylim(y_min, y_max)
-ax_right.set_xlabel("Number of Cells", fontsize=16)
-ax_right.tick_params(axis="both", labelsize=18)
+if limit_axes:
+    ax_right.set_ylim(y_min, y_max)
+ax_right.set_xlabel("Number of Cells")
 plt.setp(ax_right.get_yticklabels(), visible=False)
 
 plt.show()

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -56,6 +56,8 @@ normalize = False
 calc_selec = False
 limit_axes = True  # Set False to let matplotlib auto-scale axes to the full data range
 log_scale = False  # Set True to symlog-scale the main + marginal panels (highlights outliers). If true omits KDE display and contour lines
+show_marginals = False # Set False to show only the main 2D panel, without the top/right marginal histograms
+
 
 # Selectivity parameters
 dose = 1e-10  # ligand concentration in M
@@ -240,39 +242,49 @@ import seaborn as sns
 
 from bicytok.figure_styles import (
     FIGSIZE,
+    FONT_SIZE_LEGEND,
+    LEGEND_BORDERAXESPAD,
+    LEGEND_BORDERPAD,
+    LEGEND_HANDLELENGTH,
+    LEGEND_HANDLETEXTPAD,
+    LEGEND_LABELSPACING,
     POINT_SIZE_BACKGROUND,
     gridspec_marginal_spacing,
+    set_tick_count,
 )
 
-# Create figure with custom gridspec for marginal plots
-GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
-MARGINAL_GAP_IN = 0.25  # physical gap between main panel and each marginal histogram
+if show_marginals:
+    # Create figure with custom gridspec for marginal plots
+    GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
+    MARGINAL_GAP_IN = 0.25  # physical gap between main panel and each marginal histogram
 
-fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
-hspace, wspace = gridspec_marginal_spacing(
-    fig_width=FIGSIZE["joint_grid"][0],
-    fig_height=FIGSIZE["joint_grid"][1],
-    grid_bounds=GRID_BOUNDS,
-    n_rows=3,
-    n_cols=3,
-    gap_inches=MARGINAL_GAP_IN,
-)
-gs = gridspec.GridSpec(
-    3,
-    3,
-    figure=fig,
-    width_ratios=[1, 4, 1],
-    height_ratios=[1, 4, 0.2],
-    hspace=hspace,
-    wspace=wspace,
-    left=GRID_BOUNDS[0],
-    right=GRID_BOUNDS[1],
-    top=GRID_BOUNDS[2],
-    bottom=GRID_BOUNDS[3],
-)
-
-# Main 2D plot (center)
-ax_main = fig.add_subplot(gs[1, 1])
+    fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
+    hspace, wspace = gridspec_marginal_spacing(
+        fig_width=FIGSIZE["joint_grid"][0],
+        fig_height=FIGSIZE["joint_grid"][1],
+        grid_bounds=GRID_BOUNDS,
+        n_rows=3,
+        n_cols=3,
+        gap_inches=MARGINAL_GAP_IN,
+    )
+    gs = gridspec.GridSpec(
+        3,
+        3,
+        figure=fig,
+        width_ratios=[1, 4, 1],
+        height_ratios=[1, 4, 0.2],
+        hspace=hspace,
+        wspace=wspace,
+        left=GRID_BOUNDS[0],
+        right=GRID_BOUNDS[1],
+        top=GRID_BOUNDS[2],
+        bottom=GRID_BOUNDS[3],
+    )
+    ax_main = fig.add_subplot(gs[1, 1])
+    ax_top = fig.add_subplot(gs[0, 1], sharex=ax_main)
+    ax_right = fig.add_subplot(gs[1, 2], sharey=ax_main)
+else:
+    fig, ax_main = plt.subplots(figsize=FIGSIZE["square_scatter"], dpi=DPI)
 
 # Plot 2D data
 for i, cell_type in enumerate(
@@ -309,50 +321,58 @@ else:
     ax_main.set_xlabel(f"{receptor1} Count")
     ax_main.set_ylabel(f"{receptor2} Count")
 
-ax_main.legend()
+# Main panel is small relative to the scatter panels FONT_SIZE_LEGEND was tuned for, so
+# the legend uses a reduced local font size (built from the shared spacing constants) to
+# stay compact while remaining overlaid on the panel rather than a detached standalone legend.
+ax_main.legend(
+    fontsize=FONT_SIZE_LEGEND,
+    markerscale=1.5,
+    borderpad=LEGEND_BORDERPAD,
+    labelspacing=LEGEND_LABELSPACING,
+    handlelength=LEGEND_HANDLELENGTH,
+    handletextpad=LEGEND_HANDLETEXTPAD,
+    borderaxespad=LEGEND_BORDERAXESPAD,
+)
 
-# Top marginal plot (x-axis projection)
-ax_top = fig.add_subplot(gs[0, 1], sharex=ax_main)
+if show_marginals:
+    # Top marginal plot (x-axis projection)
+    for i, cell_type in enumerate(
+        [t for t in plot_cell_types if t in plot_df["Cell Type"].unique()]
+    ):
+        cell_df = plot_df[plot_df["Cell Type"] == cell_type]
+        sns.histplot(
+            cell_df[f"{receptor1}_norm"].values,
+            color=colors[i],
+            alpha=0.5,
+            kde=not log_scale,
+            kde_kws={"bw_method": "scott"},
+            edgecolor="black",
+            ax=ax_top,
+            label=cell_type_labels[i],
+        )
 
-for i, cell_type in enumerate(
-    [t for t in plot_cell_types if t in plot_df["Cell Type"].unique()]
-):
-    cell_df = plot_df[plot_df["Cell Type"] == cell_type]
-    sns.histplot(
-        cell_df[f"{receptor1}_norm"].values,
-        color=colors[i],
-        alpha=0.5,
-        kde=not log_scale,
-        kde_kws={"bw_method": "scott"},
-        edgecolor="black",
-        ax=ax_top,
-        label=cell_type_labels[i],
-    )
+    ax_top.set_xlim(x_min, x_max)
+    ax_top.set_ylabel("Number of Cells")
+    plt.setp(ax_top.get_xticklabels(), visible=False)
 
-ax_top.set_xlim(x_min, x_max)
-ax_top.set_ylabel("Number of Cells")
-plt.setp(ax_top.get_xticklabels(), visible=False)
+    # Right marginal plot (y-axis projection)
+    for i, cell_type in enumerate(
+        [t for t in plot_cell_types if t in plot_df["Cell Type"].unique()]
+    ):
+        cell_df = plot_df[plot_df["Cell Type"] == cell_type]
+        sns.histplot(
+            y=cell_df[f"{receptor2}_norm"].values,
+            color=colors[i],
+            alpha=0.5,
+            kde=not log_scale,
+            kde_kws={"bw_method": "scott"},
+            edgecolor="black",
+            ax=ax_right,
+        )
 
-# Right marginal plot (y-axis projection)
-ax_right = fig.add_subplot(gs[1, 2], sharey=ax_main)
-
-for i, cell_type in enumerate(
-    [t for t in plot_cell_types if t in plot_df["Cell Type"].unique()]
-):
-    cell_df = plot_df[plot_df["Cell Type"] == cell_type]
-    sns.histplot(
-        y=cell_df[f"{receptor2}_norm"].values,
-        color=colors[i],
-        alpha=0.5,
-        kde=not log_scale,
-        kde_kws={"bw_method": "scott"},
-        edgecolor="black",
-        ax=ax_right,
-    )
-
-ax_right.set_ylim(y_min, y_max)
-ax_right.set_xlabel("Number of Cells")
-plt.setp(ax_right.get_yticklabels(), visible=False)
+    ax_right.set_ylim(y_min, y_max)
+    ax_right.set_xlabel("Number of Cells")
+    plt.setp(ax_right.get_yticklabels(), visible=False)
 
 # Symlog rather than log: raw receptor counts include exact zeros, which a
 # plain log scale can't display. Counts at or below LOG_LINTHRESH stay linear;
@@ -365,6 +385,8 @@ LOG_LINTHRESH = 1
 if log_scale:
     ax_main.set_xscale("symlog", linthresh=LOG_LINTHRESH)
     ax_main.set_yscale("symlog", linthresh=LOG_LINTHRESH)
+
+set_tick_count(ax_main, 3, 3)
 
 plt.show()
 

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -56,7 +56,7 @@ normalize = False
 calc_selec = False
 limit_axes = True  # Set False to let matplotlib auto-scale axes to the full data range
 log_scale = False  # Set True to symlog-scale the main + marginal panels (highlights outliers). If true omits KDE display and contour lines
-show_marginals = False # Set False to show only the main 2D panel, without the top/right marginal histograms
+show_marginals = False  # Set False to show only the main 2D panel, without the top/right marginal histograms
 
 
 # Selectivity parameters
@@ -228,7 +228,7 @@ if limit_axes:
     x_max = np.percentile(plot_df[f"{receptor1}_norm"], 99) * 1.1
     y_max = np.percentile(plot_df[f"{receptor2}_norm"], 99) * 1.1
     x_min = y_min = 0
-else: # pad upper axes to avoid cutting off edge points
+else:  # pad upper axes to avoid cutting off edge points
     x_max = max(plot_df[f"{receptor1}_norm"]) * 1.05
     y_max = max(plot_df[f"{receptor2}_norm"]) * 1.05
 ```
@@ -256,7 +256,9 @@ from bicytok.figure_styles import (
 if show_marginals:
     # Create figure with custom gridspec for marginal plots
     GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
-    MARGINAL_GAP_IN = 0.25  # physical gap between main panel and each marginal histogram
+    MARGINAL_GAP_IN = (
+        0.25  # physical gap between main panel and each marginal histogram
+    )
 
     fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
     hspace, wspace = gridspec_marginal_spacing(

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -234,20 +234,33 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from bicytok.figure_styles import FIGSIZE
+from bicytok.figure_styles import FIGSIZE, gridspec_marginal_spacing
 
 # Create figure with custom gridspec for marginal plots
+GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
+MARGINAL_GAP_IN = 0.25  # physical gap between main panel and each marginal histogram
+
 fig = plt.figure(figsize=FIGSIZE["joint_grid"], dpi=DPI)
+hspace, wspace = gridspec_marginal_spacing(
+    fig_width=FIGSIZE["joint_grid"][0],
+    fig_height=FIGSIZE["joint_grid"][1],
+    grid_bounds=GRID_BOUNDS,
+    n_rows=3,
+    n_cols=3,
+    gap_inches=MARGINAL_GAP_IN,
+)
 gs = gridspec.GridSpec(
     3,
     3,
     figure=fig,
     width_ratios=[1, 4, 1],
     height_ratios=[1, 4, 0.2],
-    hspace=0.15,
-    wspace=0.05,
-    top=0.88,
-    bottom=0.1,
+    hspace=hspace,
+    wspace=wspace,
+    left=GRID_BOUNDS[0],
+    right=GRID_BOUNDS[1],
+    top=GRID_BOUNDS[2],
+    bottom=GRID_BOUNDS[3],
 )
 
 # Main 2D plot (center)

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -321,14 +321,14 @@ if receptor1 == "CD122":
 elif receptor1 == "CD25":
     rec_label1 = "IL-2Rα"
 else:
-    rec_label1 = receptor
+    rec_label1 = receptor1
 
 if receptor2 == "CD122":
     rec_label2 = "IL-2Rβ"
 elif receptor2 == "CD25":
     rec_label2 = "IL-2Rα"
 else:
-    rec_label2 = receptor
+    rec_label2 = receptor2
 
 if normalize:
     ax_main.set_xlabel(f"{rec_label1} Normalized Count")

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -229,7 +229,6 @@ if limit_axes:
 else: # pad upper axes to avoid cutting off edge points
     x_max = max(plot_df[f"{receptor1}_norm"]) * 1.05
     y_max = max(plot_df[f"{receptor2}_norm"]) * 1.05
-
 ```
 
 ```{python}
@@ -239,7 +238,11 @@ import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from bicytok.figure_styles import FIGSIZE, gridspec_marginal_spacing
+from bicytok.figure_styles import (
+    FIGSIZE,
+    POINT_SIZE_BACKGROUND,
+    gridspec_marginal_spacing,
+)
 
 # Create figure with custom gridspec for marginal plots
 GRID_BOUNDS = (0.125, 0.9, 0.88, 0.1)  # left, right, top, bottom (figure fraction)
@@ -282,7 +285,7 @@ for i, cell_type in enumerate(
         cell_df[f"{receptor2}_norm"],
         alpha=0.3,
         color=colors[i],
-        s=10,
+        s=POINT_SIZE_BACKGROUND,
         label=cell_type_labels[i],
     )
 

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -45,16 +45,17 @@ from bicytok.selectivity_funcs import optimize_affs
 apply_style()
 
 # Parameters
-receptor1 = "GP130"
-receptor2 = "CD202b"
-targ_cell = "Treg"
+receptor1 = "CD49a"
+receptor2 = "CD103"
+targ_cell = "CD8 TCM"
 off_targ_cell_types = None
 sample_size = 2500
 cell_categorization = "CellType2"
 plot_cell_types = [targ_cell, "other"]
 normalize = False
 calc_selec = False
-limit_axes = False  # Set False to let matplotlib auto-scale axes to the full data range
+limit_axes = True  # Set False to let matplotlib auto-scale axes to the full data range
+log_scale = False  # Set True to symlog-scale the main + marginal panels (highlights outliers). If true omits KDE display and contour lines
 
 # Selectivity parameters
 dose = 1e-10  # ligand concentration in M
@@ -70,7 +71,7 @@ valencies_2d = np.array(
 TARGET_COLOR = COLORS["target"]
 OFF_TARGET_COLOR = COLORS["off_target"]
 colors = [TARGET_COLOR, OFF_TARGET_COLOR]
-cell_type_labels = ["Target", "Off-target"]
+cell_type_labels = [targ_cell, "Off-target"]
 
 # Figure dimensions for marginal plot layout
 DPI = 100
@@ -225,6 +226,10 @@ if limit_axes:
     x_max = np.percentile(plot_df[f"{receptor1}_norm"], 99) * 1.1
     y_max = np.percentile(plot_df[f"{receptor2}_norm"], 99) * 1.1
     x_min = y_min = 0
+else: # pad upper axes to avoid cutting off edge points
+    x_max = max(plot_df[f"{receptor1}_norm"]) * 1.05
+    y_max = max(plot_df[f"{receptor2}_norm"]) * 1.05
+
 ```
 
 ```{python}
@@ -281,18 +286,18 @@ for i, cell_type in enumerate(
         label=cell_type_labels[i],
     )
 
-    sns.kdeplot(
-        x=cell_df[f"{receptor1}_norm"],
-        y=cell_df[f"{receptor2}_norm"],
-        color=colors[i],
-        levels=5,
-        linewidths=1.5,
-        ax=ax_main,
-    )
+    if not log_scale:
+        sns.kdeplot(
+            x=cell_df[f"{receptor1}_norm"],
+            y=cell_df[f"{receptor2}_norm"],
+            color=colors[i],
+            levels=5,
+            linewidths=1.5,
+            ax=ax_main,
+        )
 
-if limit_axes:
-    ax_main.set_xlim(x_min, x_max)
-    ax_main.set_ylim(y_min, y_max)
+ax_main.set_xlim(x_min, x_max)
+ax_main.set_ylim(y_min, y_max)
 
 if normalize:
     ax_main.set_xlabel(f"{receptor1} Normalized Count")
@@ -314,15 +319,14 @@ for i, cell_type in enumerate(
         cell_df[f"{receptor1}_norm"].values,
         color=colors[i],
         alpha=0.5,
-        kde=True,
+        kde=not log_scale,
         kde_kws={"bw_method": "scott"},
         edgecolor="black",
         ax=ax_top,
         label=cell_type_labels[i],
     )
 
-if limit_axes:
-    ax_top.set_xlim(x_min, x_max)
+ax_top.set_xlim(x_min, x_max)
 ax_top.set_ylabel("Number of Cells")
 plt.setp(ax_top.get_xticklabels(), visible=False)
 
@@ -337,16 +341,27 @@ for i, cell_type in enumerate(
         y=cell_df[f"{receptor2}_norm"].values,
         color=colors[i],
         alpha=0.5,
-        kde=True,
+        kde=not log_scale,
         kde_kws={"bw_method": "scott"},
         edgecolor="black",
         ax=ax_right,
     )
 
-if limit_axes:
-    ax_right.set_ylim(y_min, y_max)
+ax_right.set_ylim(y_min, y_max)
 ax_right.set_xlabel("Number of Cells")
 plt.setp(ax_right.get_yticklabels(), visible=False)
+
+# Symlog rather than log: raw receptor counts include exact zeros, which a
+# plain log scale can't display. Counts at or below LOG_LINTHRESH stay linear;
+# larger counts are log-scaled. Applied only now, after all scatter/KDE/
+# histogram calls: seaborn fits KDEs and histogram bins in the axes' *current*
+# scale space, so setting this earlier would compute those against
+# symlog-warped values instead of the raw counts, distorting their shapes.
+# sharex/sharey above propagate the scale to the marginal panels automatically.
+LOG_LINTHRESH = 1
+if log_scale:
+    ax_main.set_xscale("symlog", linthresh=LOG_LINTHRESH)
+    ax_main.set_yscale("symlog", linthresh=LOG_LINTHRESH)
 
 plt.show()
 

--- a/figures/raw_distribution_figures/raw_2D-hist.qmd
+++ b/figures/raw_distribution_figures/raw_2D-hist.qmd
@@ -316,16 +316,27 @@ for i, cell_type in enumerate(
 ax_main.set_xlim(x_min, x_max)
 ax_main.set_ylim(y_min, y_max)
 
-if normalize:
-    ax_main.set_xlabel(f"{receptor1} Normalized Count")
-    ax_main.set_ylabel(f"{receptor2} Normalized Count")
+if receptor1 == "CD122":
+    rec_label1 = "IL-2Rβ"
+elif receptor1 == "CD25":
+    rec_label1 = "IL-2Rα"
 else:
-    ax_main.set_xlabel(f"{receptor1} Count")
-    ax_main.set_ylabel(f"{receptor2} Count")
+    rec_label1 = receptor
 
-# Main panel is small relative to the scatter panels FONT_SIZE_LEGEND was tuned for, so
-# the legend uses a reduced local font size (built from the shared spacing constants) to
-# stay compact while remaining overlaid on the panel rather than a detached standalone legend.
+if receptor2 == "CD122":
+    rec_label2 = "IL-2Rβ"
+elif receptor2 == "CD25":
+    rec_label2 = "IL-2Rα"
+else:
+    rec_label2 = receptor
+
+if normalize:
+    ax_main.set_xlabel(f"{rec_label1} Normalized Count")
+    ax_main.set_ylabel(f"{rec_label2} Normalized Count")
+else:
+    ax_main.set_xlabel(f"{rec_label1} ADT Count")
+    ax_main.set_ylabel(f"{rec_label2} ADT Count")
+
 ax_main.legend(
     fontsize=FONT_SIZE_LEGEND,
     markerscale=1.5,
@@ -376,13 +387,6 @@ if show_marginals:
     ax_right.set_xlabel("Number of Cells")
     plt.setp(ax_right.get_yticklabels(), visible=False)
 
-# Symlog rather than log: raw receptor counts include exact zeros, which a
-# plain log scale can't display. Counts at or below LOG_LINTHRESH stay linear;
-# larger counts are log-scaled. Applied only now, after all scatter/KDE/
-# histogram calls: seaborn fits KDEs and histogram bins in the axes' *current*
-# scale space, so setting this earlier would compute those against
-# symlog-warped values instead of the raw counts, distorting their shapes.
-# sharex/sharey above propagate the scale to the marginal panels automatically.
 LOG_LINTHRESH = 1
 if log_scale:
     ax_main.set_xscale("symlog", linthresh=LOG_LINTHRESH)
@@ -398,27 +402,4 @@ print(f"Y-axis ({receptor2}) KL Divergence: {kl_val_2:.4f}")
 print(f"Y-axis ({receptor2}) EMD: {emd_val_2:.4f}")
 print(f"2D ({receptor1}+{receptor2}) KL Divergence: {kl_val_2d:.4f}")
 print(f"2D ({receptor1}+{receptor2}) EMD: {emd_val_2d:.4f}")
-```
-
-## Parameter Summary
-```{python}
-#| output: asis
-text = f"""
-Generated a combined marginal plot showing the 2D joint distribution of **{receptor1}** and **{receptor2}** with 1D projections along each axis. The visualization includes:
-
-- **Center panel**: 2D scatter plot with KDE contours showing the joint distribution
-- **Top panel**: 1D histogram showing projection of all points onto the {receptor1} axis
-- **Right panel**: 1D histogram showing projection of all points onto the {receptor2} axis
-
-Analysis compared target cell type **{targ_cell}** vs off-target cells using **{sample_size}** cells from the CITE-seq dataset. The marginal histograms show both individual cell type distributions and the overall projection (gray dashed line) to visualize what happens when all 2D points are collapsed onto each axis. Target cells are shown in {TARGET_COLOR} and off-target cells in {OFF_TARGET_COLOR}. Receptor counts were {"**normalized**" if normalize else "**not normalized**"}.
-
-**Selectivity Analysis**: Using **{signal[0]}** as the signaling receptor, selectivity was calculated for:
-- 1D case with {signal[0]}+{receptor1}: **{selectivity_1d_rec1:.2f}**
-- 1D case with {signal[0]}+{receptor2}: **{selectivity_1d_rec2:.2f}**
-- 2D case with {signal[0]}+{receptor1}+{receptor2}: **{selectivity_2d:.2f}**
-
-Selectivity values represent the ratio of target to off-target binding after optimization at dose **{dose:.0e} M** using valencies {valencies_1d.flatten()} (1D) and {valencies_2d.flatten()} (2D).
-"""
-
-print(text)
 ```

--- a/figures/scanning_analyses/scan_alluvial_flows.qmd
+++ b/figures/scanning_analyses/scan_alluvial_flows.qmd
@@ -1,0 +1,443 @@
+---
+title: "Cross-Scan Receptor-Pair Category Flow"
+---
+
+# Summary
+Visualizes how individual receptor pairs move between categorical groupings as scan conditions change, via alluvial (flow) diagrams. Each pair is labeled by a category under one scan, matched to the same pair (by cell type + receptor identity) under another scan, and a flow diagram shows how the categories redistribute — revealing which pool each destination category is pulled from. This complements `scan_kxstar_bounds.qmd`, which tracks the distribution of optimal binding-model *parameters* (Kx*, affinities, selectivity, gain) rather than which category a pair falls into.
+
+Two flows are drawn:
+
+1. **Co-pinning flow** (`fig-copinning`): Kx* and target affinity are compensatory avidity sources, so a pair that has maxed both has no headroom left — it is genuinely constrained by the Kx* bound. Each pair is labeled by whether it is pinned at its Kx* upper bound and whether either target arm sits at the affinity ceiling, giving four categories. Pairs are matched between the loose (1e-5) and tight (1e-9) Kx* bound scans, and the alluvial shows how the loose-bound categories redistribute under the tight bound.
+2. **Selectivity/gain flow** (`fig-selgain-flow`): each pair is labeled by selectivity (below/above `SELEC_HIGH_CUTOFF`) crossed with selectivity gain (non-synergistic/synergistic, i.e. `log2_gain <= 0` vs `> 0`), and pairs are matched between the monovalent and bivalent scans to show which quadrant increased valency pulls each pair into — in particular, whether low-selectivity, high-gain pairs move into the high-selectivity, high-gain quadrant.
+
+Both flows share the same rendering machinery (`draw_category_flow`, `plot_flow`): source-scan and destination-scan blocks sit at the top and bottom of the figure, sized by pair count, connected by ribbons flowing top-to-bottom and colored by source category, so each destination block's composition shows where its pairs came from.
+
+# Inputs
+All user-facing parameters are collected at the top of the code cell below, ahead of the data loading and plotting mechanics.
+
+- `SCANS`: the three selectivity scans these flows compare — loose (1e-5) and tight (1e-9) Kx* bound scans (for `fig-copinning`), and the loose-bound and bivalent scans (for `fig-selgain-flow`). Each has a CSV `path`, a display `label`, and the `kx_upper` optimization bound in log10(M). Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory.
+- `AFFINITY_OPT_BOUNDS`: true (min, max) affinity optimization bounds in log10(M), used to detect whether a target arm sits at the affinity ceiling.
+- `SELEC_HIGH_CUTOFF` / `GAIN_HIGH_CUTOFF`: selectivity/gain thresholds defining the `fig-selgain-flow` quadrants; also exposed as `build_selgain_flow`/`plot_selgain_flow` arguments so they can be tuned to isolate a specific population (e.g. pairs only reaching meaningful gain at high valency) without editing the module-level defaults.
+
+# Outputs
+- **`fig-copinning`**: cross-scan alluvial flow of pairs between four constraint categories (Kx*-pinned x target-affinity-ceiling), showing where each tight-bound category is pulled from
+- **`fig-copinning-legend`**: standalone legend for `fig-copinning`'s constraint categories, detached so it can be positioned independently (e.g. in Illustrator) rather than crowding the flow figure.
+- **`fig-selgain-flow`**: cross-scan (monovalent -> bivalent) alluvial flow of pairs between four selectivity x gain quadrants, showing which quadrant increased valency pulls each pair into
+- **`fig-selgain-pos-flow`**: same as `fig-selgain-flow`, restricted to pairs gain+ in the monovalent or bivalent scan (`gain_positive_only=True`), so the (otherwise tiny) gain+ population's own selectivity movement isn't diluted by the much larger gain- bulk
+- **`fig-selgain-flow-legend`**: standalone legend for `fig-selgain-flow`'s selectivity/gain quadrants, detached per `fig-copinning-legend`. Shared by `fig-selgain-pos-flow`, which uses the same four quadrants.
+
+```{python}
+%config InlineBackend.figure_formats = ['svg']
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import yaml
+from matplotlib.patches import Patch, Rectangle
+
+from bicytok.figure_styles import (
+    CROSSED_CONDITION_COLORS,
+    FIGSIZE,
+    FONT_SIZE_ANNOT,
+    FONT_SIZE_LABEL,
+    apply_style,
+    standalone_legend_figure,
+)
+
+apply_style()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Parameters — everything below this line and above "Data loading" is meant to be
+# edited to retarget this file at new scans or thresholds.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# fig-copinning matches SCAN_LOOSE <-> SCAN_TIGHT; fig-selgain-flow matches
+# SCAN_LOOSE <-> SCAN_BIVALENT. See scan_kxstar_bounds.qmd for the full scan pool
+# (including the mixed-valency scan, unused by either flow here).
+SCANS = [
+    {
+        "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv",
+        "label": "Kx* upper bound 1e-5",
+        "kx_upper": -5.0,
+    },
+    {
+        "path": "/home/sama/receptor_sweep_data/20260720_selec_scan_rand42_prot1.csv",
+        "label": "Kx* upper bound 1e-9",
+        "kx_upper": -9.0,
+    },
+    {
+        "path": "/home/sama/receptor_sweep_data/20260529_selec_scan_full_bival.csv",
+        "label": "Bivalent Kx* upper bound 1e-5",
+        "kx_upper": -5.0,
+    },
+]
+SCAN_LOOSE = next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5")
+SCAN_TIGHT = next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-9")
+SCAN_BIVALENT = next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5")
+
+# Affinity CSV columns needed to load each scan.
+AFF_COLS = {
+    "Affinity_Receptor_0": "Signal receptor",
+    "Affinity_Receptor_1": "Target receptor 1",
+    "Affinity_Receptor_2": "Target receptor 2",
+}
+
+# Signal (readout) receptor name, excluded from pair membership because a pair containing
+# the artificial signal receptor is not a genuine two-target combination.
+SIGNAL_REC_NAME = "Prototype_Signal_Receptor"
+
+# True affinity optimization bounds, log10(M): a target affinity within AFF_CEIL_EPS of the
+# upper bound counts as sitting "at the ceiling". A pair's Kx* is "pinned" within PIN_TOL of
+# its scan's upper bound.
+AFFINITY_OPT_BOUNDS = (6.0, 12.0)
+AFF_CEIL_EPS = 1e-2
+PIN_TOL = 1e-2
+
+# Category display names for fig-copinning. Order must match classify_copinning's coding
+# below: 0 both interior, 1 aff ceiling only, 2 Kx* pinned only, 3 doubly pinned.
+COPINNING_CAT_NAMES = [
+    "Both interior",
+    "Aff ceiling only",
+    "Kx* pinned only",
+    "Doubly pinned",
+]
+
+# Selectivity/gain quadrant thresholds and display names for fig-selgain-flow.
+# SELEC_HIGH_CUTOFF marks pairs selective enough to be manuscript-relevant. GAIN_HIGH_CUTOFF
+# is a log2 gain threshold; 0 (the default) is the synergy line (bispecific beats the better
+# monospecific constituent), but both cutoffs are also exposed as build_selgain_flow/
+# plot_selgain_flow arguments so they can be tuned to isolate a specific population (e.g.
+# pairs only reaching meaningful gain at high valency) without editing these defaults.
+# SEL_GAIN_CAT_NAMES order must match classify_selectivity_gain's coding below: 0 low
+# selectivity & gain <= cutoff, 1 low selectivity & gain > cutoff, 2 high selectivity &
+# gain <= cutoff, 3 high selectivity & gain > cutoff.
+SELEC_HIGH_CUTOFF = 0.91
+GAIN_HIGH_CUTOFF = 0.0
+SEL_GAIN_CAT_NAMES = [
+    "Low selectivity, gain-",
+    "Low selectivity, gain+",
+    "High selectivity, gain-",
+    "High selectivity, gain+",
+]
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Data loading
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def load_scan_outputs(scan):
+    """Return a DataFrame of successfully optimized pairs for one selectivity scan.
+
+    Rows with NaN outputs (uncomputed upper triangle, failed optimizations) are
+    dropped; these are NaN across all output columns simultaneously.
+    """
+    yaml_path = os.path.splitext(scan["path"])[0] + ".yaml"
+    assert os.path.exists(yaml_path), f"YAML not found at {yaml_path}"
+    with open(yaml_path) as f:
+        assert yaml.safe_load(f)["scan_type"] == "selectivity", (
+            f"{scan['path']} is not a selectivity scan; Kx* and affinities are only "
+            "optimized there."
+        )
+
+    cols = [
+        "Cell_Type",
+        "Receptor_1",
+        "Receptor_2",
+        "Selectivity",
+        "Kx_star",
+        *AFF_COLS,
+    ]
+    return pd.read_csv(scan["path"], usecols=cols).dropna(subset=["Selectivity"])
+
+
+scan_dfs = {scan["label"]: load_scan_outputs(scan) for scan in SCANS}
+
+
+def compute_pair_gains(df):
+    """Return off-diagonal pairs with an added synergy gain column.
+
+    gain = bispecific selectivity / max(constituent monospecific selectivities), where the
+    monospecific values are the diagonal (rec == rec) entries. The artificial signal
+    receptor is excluded from pair membership. Rows retain all binding-model outputs so the
+    returned table also serves the per-pair metric comparisons downstream.
+    """
+    mono_map = df[df["Receptor_1"] == df["Receptor_2"]].set_index(
+        ["Cell_Type", "Receptor_1"]
+    )["Selectivity"]
+    assert mono_map.index.is_unique, (
+        "Duplicate monospecific (cell type, receptor) entries."
+    )
+
+    pairs = df[
+        (df["Receptor_1"] != df["Receptor_2"])
+        & (df["Receptor_1"] != SIGNAL_REC_NAME)
+        & (df["Receptor_2"] != SIGNAL_REC_NAME)
+    ].copy()
+    mono1 = mono_map.reindex(
+        list(zip(pairs["Cell_Type"], pairs["Receptor_1"], strict=True))
+    ).to_numpy()
+    mono2 = mono_map.reindex(
+        list(zip(pairs["Cell_Type"], pairs["Receptor_2"], strict=True))
+    ).to_numpy()
+    pairs["max_mono_selec"] = np.maximum(mono1, mono2)
+    pairs["gain"] = pairs["Selectivity"] / pairs["max_mono_selec"]
+    pairs["log2_gain"] = np.log2(pairs["gain"])
+    return pairs.dropna(subset=["gain"])
+
+
+pair_dfs = {lbl: compute_pair_gains(df) for lbl, df in scan_dfs.items()}
+
+
+def pair_key(df):
+    """Stable per-pair key (cell type + sorted receptor pair) for matching across scans."""
+    recs = np.sort(df[["Receptor_1", "Receptor_2"]].to_numpy(), axis=1)
+    return df["Cell_Type"].to_numpy() + "|" + recs[:, 0] + "|" + recs[:, 1]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared flow helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Shared palette for both flow figures (CROSSED_CONDITION_COLORS: reused from
+# scan_outliers.qmd's outlier categories, which have the same neither/A-only/B-only/both
+# shape): index 0 is "neither condition", 3 is "both conditions", 1/2 are each condition
+# alone (see each category-name list above for the specific conditions).
+FLOW_CAT_COLORS = CROSSED_CONDITION_COLORS
+
+
+def classify_copinning(df, kx_upper):
+    """Label each pair by constraint category and build a cross-scan matching key.
+
+    Category codes: 0 both interior, 1 aff ceiling only, 2 Kx* pinned only, 3 doubly pinned.
+    The key (cell type + sorted receptor pair) identifies the same pair across scans.
+    """
+    kx_pinned = (np.abs(df["Kx_star"] - kx_upper) < PIN_TOL).to_numpy()
+    aff_ceiling = (
+        np.maximum(df["Affinity_Receptor_1"], df["Affinity_Receptor_2"])
+        > AFFINITY_OPT_BOUNDS[1] - AFF_CEIL_EPS
+    ).to_numpy()
+    return pd.DataFrame(
+        {
+            "key": pair_key(df),
+            "cat": 2 * kx_pinned.astype(int) + aff_ceiling.astype(int),
+        }
+    )
+
+
+def classify_selectivity_gain(df, selec_cutoff, gain_cutoff):
+    """Label each pair by selectivity/gain quadrant and build a cross-scan matching key.
+
+    Category codes: 0 low selectivity & gain <= gain_cutoff, 1 low selectivity &
+    gain > gain_cutoff, 2 high selectivity & gain <= gain_cutoff, 3 high selectivity &
+    gain > gain_cutoff.
+    """
+    high_sel = (df["Selectivity"] >= selec_cutoff).to_numpy()
+    high_gain = (df["log2_gain"] > gain_cutoff).to_numpy()
+    return pd.DataFrame(
+        {
+            "key": pair_key(df),
+            "cat": 2 * high_sel.astype(int) + high_gain.astype(int),
+        }
+    )
+
+
+def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03):
+    """Alluvial flow between two scans' category assignments.
+
+    Source-scan and destination-scan blocks sit at the top and bottom of the flow axis,
+    sized proportional to pair counts; ribbons connect them, colored by source category so
+    each destination block's composition shows where its pairs came from. Flows top-to-bottom
+    (source top, destination bottom, blocks laid out along x) for a wide/short footprint.
+    """
+    total = trans.sum()
+    n_cat = trans.shape[0]
+    size_a, size_b = trans.sum(axis=1), trans.sum(axis=0)
+    usable = 1 - gap * (n_cat - 1)
+
+    def block_edges(sizes):
+        edges, top = [], 1.0
+        for s in sizes:
+            height = s / total * usable
+            edges.append((top, top - height))
+            top -= height + gap
+        return edges
+
+    edges_a, edges_b = block_edges(size_a), block_edges(size_b)
+
+    for edges, y0 in [(edges_a, 1.0), (edges_b, -bar_w)]:
+        for cat, (top, bot) in enumerate(edges):
+            ax.add_patch(
+                Rectangle(
+                    (bot, y0),
+                    top - bot,
+                    bar_w,
+                    color=colors[cat],
+                    ec="white",
+                    lw=0.5,
+                    zorder=3,
+                )
+            )
+
+    cursor_a = [top for top, _ in edges_a]
+    cursor_b = [top for top, _ in edges_b]
+    xs = np.linspace(0, 1, 60)
+    ease = (1 - np.cos(np.pi * xs)) / 2
+    flow_axis = 1 - xs  # flows top (1) to bottom (0)
+    for a in range(n_cat):
+        for b in range(n_cat):
+            if trans[a, b] == 0:
+                continue
+            height = trans[a, b] / total * usable
+            l_top, l_bot = cursor_a[a], cursor_a[a] - height
+            r_top, r_bot = cursor_b[b], cursor_b[b] - height
+            cursor_a[a], cursor_b[b] = l_bot, r_bot
+            lower = l_bot + (r_bot - l_bot) * ease
+            upper = l_top + (r_top - l_top) * ease
+            ax.fill_betweenx(
+                flow_axis, lower, upper, color=colors[a], alpha=0.45, lw=0, zorder=1
+            )
+
+    label_spots = [
+        (edges_a, 1.0 + bar_w + 0.015, "bottom"),
+        (edges_b, -bar_w - 0.015, "top"),
+    ]
+    for edges, off, align in label_spots:
+        sizes = size_a if edges is edges_a else size_b
+        for cat, (top, bot) in enumerate(edges):
+            if sizes[cat] / total <= 0.01:
+                continue
+            center = (top + bot) / 2
+            ax.text(
+                center,
+                off,
+                f"{sizes[cat] / total * 100:.0f}%",
+                fontsize=FONT_SIZE_ANNOT,
+                ha="center",
+                va=align,
+            )
+
+    ax.set_xlim(-0.02, 1.09)
+    ax.set_ylim(-0.34, 1.34)
+    ax.axis("off")
+
+
+def transition_from_matched(matched, n_cat):
+    """Category transition matrix from an already cats_a/cats_b-merged pair table."""
+    cats = range(n_cat)
+    return (
+        pd.crosstab(matched["cat_a"], matched["cat_b"])
+        .reindex(index=cats, columns=cats, fill_value=0)
+        .to_numpy()
+    )
+
+
+def pairs_to_transition(cats_a, cats_b, n_cat):
+    """Cross-scan category transition matrix from two classified pair tables (key, cat)."""
+    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+    return transition_from_matched(matched, n_cat)
+
+
+def build_copinning_flow(scan_a, scan_b):
+    """Compute the co-pinning category transition matrix between two scans."""
+    cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
+    cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
+    return pairs_to_transition(cats_a, cats_b, len(COPINNING_CAT_NAMES))
+
+
+def build_selgain_flow(
+    scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only=False
+):
+    """Compute the selectivity/gain quadrant transition matrix between two scans.
+
+    gain_positive_only restricts to pairs classified gain+ (categories 1 or 3, i.e.
+    cat % 2 == 1) in scan_a or scan_b. The gain+ population is a small fraction of all
+    pairs, so without this the transition percentages are dominated by gain- pairs sitting
+    still; restricting to "ever gain+" pairs makes the gain+ population's own selectivity
+    movement legible instead of being diluted by the much larger gain- bulk.
+    """
+    cats_a = classify_selectivity_gain(
+        pair_dfs[scan_a["label"]], selec_cutoff, gain_cutoff
+    )
+    cats_b = classify_selectivity_gain(
+        pair_dfs[scan_b["label"]], selec_cutoff, gain_cutoff
+    )
+    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+    if gain_positive_only:
+        matched = matched[(matched["cat_a"] % 2 == 1) | (matched["cat_b"] % 2 == 1)]
+    return transition_from_matched(matched, len(SEL_GAIN_CAT_NAMES))
+
+
+def plot_flow(trans, label_a, label_b):
+    """Draw a category-transition alluvial from label_a (top) to label_b (bottom) as a
+    standalone figure.
+
+    Shared renderer for fig-copinning and fig-selgain-flow: trans carries the figure-specific
+    data, so this function only knows about the generic category flow, not what a category
+    represents. The legend is detached (see flow_legend_figure), so ribbon colors alone would
+    be ambiguous without it.
+    """
+    fig, ax = plt.subplots(figsize=FIGSIZE["alluvial_flow"])
+    draw_category_flow(ax, trans, FLOW_CAT_COLORS)
+    ax.text(0.5, 1.19, label_a, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
+    ax.text(0.5, -0.19, label_b, ha="center", va="top", fontsize=FONT_SIZE_LABEL)
+    plt.tight_layout()
+    plt.show()
+
+
+def flow_legend_figure(cat_names):
+    """Standalone legend mapping FLOW_CAT_COLORS to cat_names, detached so it can be
+    positioned independently (e.g. in Illustrator) rather than crowding plot_flow.
+    """
+    handles = [Patch(facecolor=FLOW_CAT_COLORS[i]) for i in range(len(cat_names))]
+    return standalone_legend_figure(handles, cat_names, ncol=len(cat_names))
+
+
+def plot_copinning(scan_a, scan_b):
+    """Draw the co-pinning alluvial flow from scan_a to scan_b as a standalone figure."""
+    trans = build_copinning_flow(scan_a, scan_b)
+    plot_flow(trans, scan_a["label"], scan_b["label"])
+
+
+def plot_selgain_flow(
+    scan_a,
+    scan_b,
+    selec_cutoff=SELEC_HIGH_CUTOFF,
+    gain_cutoff=GAIN_HIGH_CUTOFF,
+    gain_positive_only=False,
+):
+    """Draw the selectivity/gain quadrant alluvial flow from scan_a to scan_b."""
+    trans = build_selgain_flow(
+        scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only
+    )
+    plot_flow(trans, scan_a["label"], scan_b["label"])
+```
+
+```{python}
+#| label: fig-copinning
+plot_copinning(SCAN_LOOSE, SCAN_TIGHT)
+```
+
+```{python}
+#| label: fig-copinning-legend
+#| fig-cap: "Shared legend for fig-copinning's constraint categories"
+flow_legend_figure(COPINNING_CAT_NAMES)
+plt.show()
+```
+
+```{python}
+#| label: fig-selgain-flow
+plot_selgain_flow(SCAN_LOOSE, SCAN_BIVALENT, gain_positive_only=False)
+```
+
+```{python}
+#| label: fig-selgain-pos-flow
+plot_selgain_flow(SCAN_LOOSE, SCAN_BIVALENT, gain_positive_only=True, gain_cutoff=0.01)
+```
+
+```{python}
+#| label: fig-selgain-flow-legend
+#| fig-cap: "Shared legend for fig-selgain-flow's selectivity/gain quadrants"
+flow_legend_figure(SEL_GAIN_CAT_NAMES)
+plt.show()
+```

--- a/figures/scanning_analyses/scan_alluvial_flows.qmd
+++ b/figures/scanning_analyses/scan_alluvial_flows.qmd
@@ -3,11 +3,11 @@ title: "Cross-Scan Receptor-Pair Category Flow"
 ---
 
 # Summary
-Visualizes how individual receptor pairs move between categorical groupings as scan conditions change, via alluvial (flow) diagrams. Each pair is labeled by a category under one scan, matched to the same pair (by cell type + receptor identity) under another scan, and a flow diagram shows how the categories redistribute — revealing which pool each destination category is pulled from. This complements `scan_kxstar_bounds.qmd`, which tracks the distribution of optimal binding-model *parameters* (Kx*, affinities, selectivity, gain) rather than which category a pair falls into.
+Visualizes how individual receptor pairs move between categorical groupings as scan conditions change, via alluvial (flow) diagrams. Each pair is labeled by a category under one scan, matched to the same pair (by cell type + receptor identity) under another scan, and a flow diagram shows how the categories redistribute — revealing which pool each destination category is pulled from.
 
 Two flows are drawn:
 
-1. **Co-pinning flow** (`fig-copinning`): Kx* and target affinity are compensatory avidity sources, so a pair that has maxed both has no headroom left — it is genuinely constrained by the Kx* bound. Each pair is labeled by whether it is pinned at its Kx* upper bound and whether either target arm sits at the affinity ceiling, giving four categories. Pairs are matched between the loose (1e-5) and tight (1e-9) Kx* bound scans, and the alluvial shows how the loose-bound categories redistribute under the tight bound.
+1. **Co-pinning flow** (`fig-copinning`): Each pair is labeled by whether it is pinned at its Kx* upper bound and whether either target arm sits at the affinity ceiling, giving four categories. Pairs are matched between the loose (1e-5) and tight (1e-9) Kx* bound scans, and the alluvial shows how the loose-bound categories redistribute under the tight bound.
 2. **Selectivity/gain flow** (`fig-selgain-flow`): each pair is labeled by selectivity (below/above `SELEC_HIGH_CUTOFF`) crossed with selectivity gain (non-synergistic/synergistic, i.e. `log2_gain <= 0` vs `> 0`), and pairs are matched between the monovalent and bivalent scans to show which quadrant increased valency pulls each pair into — in particular, whether low-selectivity, high-gain pairs move into the high-selectivity, high-gain quadrant.
 
 Both flows share the same rendering machinery (`draw_category_flow`, `plot_flow`): source-scan and destination-scan blocks sit at the top and bottom of the figure, sized by pair count, connected by ribbons flowing top-to-bottom and colored by source category, so each destination block's composition shows where its pairs came from.

--- a/figures/scanning_analyses/scan_bar_plots.qmd
+++ b/figures/scanning_analyses/scan_bar_plots.qmd
@@ -26,7 +26,7 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from figures.scanning_analyses.scan_runners import (
+from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -480,6 +480,6 @@ _legend_handles.append(
 )
 _legend_labels = [*_legend_cell_types, "Top pair per axis"]
 
-standalone_legend_figure(_legend_handles, _legend_labels, title="Cell type")
+standalone_legend_figure(_legend_handles, _legend_labels, ncol=2, title="Cell type")
 plt.show()
 ```

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -43,9 +43,13 @@ implementation drives several manuscript figures with different parameters.
 - **`fig-scan-comp-kl-selec-treg`**: KL divergence vs binding-model selectivity, Treg only
 - **`fig-scan-comp-emd-selec-cd8tcm`**: EMD vs binding-model selectivity, CD8 TCM only
 - **`fig-scan-comp-emd-selec-pdc`**: EMD vs binding-model selectivity, pDC only
+- **`fig-scan-comp-celltype-legend`**: the cell-type-to-color legend, detached from the
+  "all cell types" panels above so it can be positioned independently (e.g. in
+  Illustrator) rather than repeated identically in each panel
 
-Each panel: x = metric 1, y = metric 2, one color per cell type; all receptor pairs
-plotted as equal-sized points with the top pair per axis starred.
+Each panel: x = metric 1, y = metric 2, one color per cell type (from the project-wide
+canonical `CELL_TYPE_COLORS`); all receptor pairs plotted as equal-sized points with the
+top pair per axis starred.
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
@@ -59,13 +63,11 @@ import yaml
 from scipy.stats import spearmanr
 
 from bicytok.figure_styles import (
-    CMAPS,
+    CELL_TYPE_COLORS,
     FIGSIZE,
-    POINT_SIZE_BACKGROUND,
     POINT_SIZE_FOREGROUND,
     POINT_SIZE_XS,
     apply_style,
-    categorical_colors,
 )
 
 apply_style()
@@ -76,9 +78,12 @@ apply_style()
 AXIS_NORM = "none"  # "none", "z-score", "rank"
 RASTERIZE_SCATTER = False
 
+# Show a legend on each panel. Off by default since every "all cell types" comparison
+# shares the same canonical cell-type coloring; see fig-scan-comp-celltype-legend for
+# the detached, shared legend instead (kept separate for easier Illustrator layout).
 DISP_LEGEND = False
 
-POINT_ALPHA = 0.15
+POINT_ALPHA = 0.35
 
 # Exclude the degenerate low-selectivity "basin" from Spearman correlation for any
 # comparison involving the Selectivity metric (still shown on the plot, with a dashed
@@ -257,13 +262,12 @@ def build_comparison(metric_a, metric_b, cell_types, axis_norm):
         all_df["s2"] = all_df["s2"].rank(method="average")
 
     suffix = {"none": "", "z-score": " (z-score)", "rank": " (rank)"}[axis_norm]
-    cell_type_colors = dict(
-        zip(
-            cell_types,
-            categorical_colors(len(cell_types), cmap_name=CMAPS["categorical_large"]),
-            strict=True,
-        )
-    )
+    # Looked up from the project-wide canonical CELL_TYPE_COLORS (see
+    # bicytok.figure_styles) rather than resampled per comparison, so a given cell
+    # type is always the same color regardless of which/how-many cell types this
+    # particular comparison happens to include (a single-cell-type comparison like
+    # "kl_selec_treg" previously always drew whatever color index 0 was).
+    cell_type_colors = {ct: CELL_TYPE_COLORS[ct] for ct in cell_types}
     return {
         "df": all_df,
         "cell_types": cell_types,
@@ -440,4 +444,42 @@ plot_comparison("selec_selec-highval")
 ```{python}
 #| label: fig-scan-comp-selec-selec-mixval
 plot_comparison("selec_selec-mixval")
+```
+
+```{python}
+#| label: fig-scan-comp-celltype-legend
+#| fig-cap: "Shared legend for the cell-type-colored comparison scatter plots above"
+# Detached legend, mirroring suppfig-scan-outliers-legend and fig-celltype-legend
+# (scan_kxstar_bounds.qmd): every "all cell types" comparison above uses the same
+# canonical CELL_TYPE_COLORS mapping and omits its own legend, so this one legend
+# covers all of them and can be positioned independently (e.g. in Illustrator).
+import matplotlib.lines as mlines
+import matplotlib.pyplot as plt
+
+from bicytok.figure_styles import CELL_TYPE_COLORS, CELL_TYPES, standalone_legend_figure
+
+_legend_cell_types = sorted(
+    set().union(*(res["cell_types"] for res in comparison_data.values())),
+    key=CELL_TYPES.index,
+)
+_legend_handles = [
+    mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
+    for ct in _legend_cell_types
+]
+_legend_handles.append(
+    mlines.Line2D(
+        [],
+        [],
+        marker="*",
+        linestyle="None",
+        markerfacecolor="gray",
+        markeredgecolor="black",
+        markeredgewidth=0.5,
+        color="gray",
+    )
+)
+_legend_labels = [*_legend_cell_types, "Top pair per axis"]
+
+standalone_legend_figure(_legend_handles, _legend_labels, title="Cell type")
+plt.show()
 ```

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -37,6 +37,10 @@ import pandas as pd
 import yaml
 from scipy.stats import spearmanr
 
+from bicytok.figure_styles import CMAPS, FIGSIZE, apply_style, categorical_colors
+
+apply_style()
+
 # ── Parameters ────────────────────────────────────────────────────────────────
 
 FILTER_SELEC_BASIN = True
@@ -149,18 +153,20 @@ comparison_data = {
 }
 
 # ── Shared cell-type color map ─────────────────────────────────────────────────
-_cmap = plt.colormaps["tab20"]
-cell_type_colors = {
-    ct: _cmap(i / max(len(TARG_CELL_TYPES) - 1, 1))
-    for i, ct in enumerate(TARG_CELL_TYPES)
-}
+cell_type_colors = dict(
+    zip(
+        TARG_CELL_TYPES,
+        categorical_colors(len(TARG_CELL_TYPES), cmap_name=CMAPS["categorical_large"]),
+        strict=True,
+    )
+)
 
 
 def plot_comparison(key):
     """Scatter one pairwise metric comparison, overlaying all cell types."""
     all_df, axis_1_label, axis_2_label = comparison_data[key]
 
-    fig, ax = plt.subplots(figsize=(7, 7))
+    fig, ax = plt.subplots(figsize=FIGSIZE["square_scatter"])
 
     for cell_type in TARG_CELL_TYPES:
         df = all_df[all_df["cell_type"] == cell_type]
@@ -215,17 +221,10 @@ def plot_comparison(key):
                 label="Top pair per axis",
             )
         )
-        ax.legend(
-            handles=handles,
-            title="Cell type",
-            fontsize=9,
-            title_fontsize=10,
-            framealpha=0.8,
-        )
+        ax.legend(handles=handles, title="Cell type")
 
-    ax.set_xlabel(axis_1_label, fontsize=13)
-    ax.set_ylabel(axis_2_label, fontsize=13)
-    ax.tick_params(labelsize=11)
+    ax.set_xlabel(axis_1_label)
+    ax.set_ylabel(axis_2_label)
     plt.tight_layout()
     plt.show()
 

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -58,7 +58,14 @@ import pandas as pd
 import yaml
 from scipy.stats import spearmanr
 
-from bicytok.figure_styles import CMAPS, FIGSIZE, apply_style, categorical_colors
+from bicytok.figure_styles import (
+    CMAPS,
+    FIGSIZE,
+    POINT_SIZE_BACKGROUND,
+    POINT_SIZE_FOREGROUND,
+    apply_style,
+    categorical_colors,
+)
 
 apply_style()
 
@@ -70,7 +77,6 @@ RASTERIZE_SCATTER = False
 
 DISP_LEGEND = False
 
-POINT_SIZE = 12
 POINT_ALPHA = 0.35
 
 # Exclude the degenerate low-selectivity "basin" from Spearman correlation for any
@@ -269,7 +275,7 @@ def plot_comparison(key):
         ax.scatter(
             df["s1"],
             df["s2"],
-            s=POINT_SIZE,
+            s=POINT_SIZE_BACKGROUND,
             alpha=POINT_ALPHA,
             color=cell_type_colors[cell_type],
             linewidths=0,
@@ -284,7 +290,7 @@ def plot_comparison(key):
             ax.scatter(
                 row["s1"],
                 row["s2"],
-                s=POINT_SIZE * 10,
+                s=POINT_SIZE_FOREGROUND,
                 marker="*",
                 color=cell_type_colors[row["cell_type"]],
                 edgecolors="black",

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -63,6 +63,7 @@ from bicytok.figure_styles import (
     FIGSIZE,
     POINT_SIZE_BACKGROUND,
     POINT_SIZE_FOREGROUND,
+    POINT_SIZE_XS,
     apply_style,
     categorical_colors,
 )
@@ -77,7 +78,7 @@ RASTERIZE_SCATTER = False
 
 DISP_LEGEND = False
 
-POINT_ALPHA = 0.35
+POINT_ALPHA = 0.15
 
 # Exclude the degenerate low-selectivity "basin" from Spearman correlation for any
 # comparison involving the Selectivity metric (still shown on the plot, with a dashed
@@ -88,6 +89,8 @@ SELEC_BASIN_CUTOFF = 0.51
 _DATA = "/home/sama/receptor_sweep_data"
 SELEC_SCAN_PATH = f"{_DATA}/20260520_selec_scan_full.csv"
 KL_EMD_SCAN_PATH = f"{_DATA}/20260520_dist_scan_full_filt.csv"
+SELEC_SCAN_PATH_BIVAL = f"{_DATA}/20260529_selec_scan_full_bival.csv"
+SELEC_SCAN_PATH_MIXVAL = f"{_DATA}/20260608_selec_scan_full_mix-val.csv"
 
 # Each metric: display label -> (scan path, CSV column, human-readable axis label).
 METRICS = {
@@ -102,6 +105,21 @@ METRICS = {
         "column": "Selectivity",
         "label": "Binding model selectivity",
     },
+    "Selectivity monoval": {
+        "path": SELEC_SCAN_PATH,
+        "column": "Selectivity",
+        "label": "Monovalent target selectivity",
+    },
+    "Selectivity bival": {
+        "path": SELEC_SCAN_PATH_BIVAL,
+        "column": "Selectivity",
+        "label": "Bivalent target selectivity",
+    },
+    "Selectivity mix-val": {
+        "path": SELEC_SCAN_PATH_MIXVAL,
+        "column": "Selectivity",
+        "label": "Mixed-valency target selectivity",
+    },
 }
 
 # Each comparison: two metric labels drawn from METRICS, and target cell types
@@ -113,6 +131,12 @@ COMPARISONS = {
     "kl_selec_treg": dict(metrics=("Selectivity", "KL"), cell_types=["Treg"]),
     "emd_selec_cd8tcm": dict(metrics=("Selectivity", "EMD"), cell_types=["CD8 TCM"]),
     "emd_selec_pdc": dict(metrics=("Selectivity", "EMD"), cell_types=["pDC"]),
+    "selec_selec-highval": dict(
+        metrics=("Selectivity monoval", "Selectivity bival"), cell_types="all", rasterize=True, hide_stars=True
+    ),
+    "selec_selec-mixval": dict(
+        metrics=("Selectivity monoval", "Selectivity mix-val"), cell_types="all", rasterize=True, hide_stars=True
+    ),
 }
 
 
@@ -275,7 +299,7 @@ def plot_comparison(key):
         ax.scatter(
             df["s1"],
             df["s2"],
-            s=POINT_SIZE_BACKGROUND,
+            s=POINT_SIZE_XS,
             alpha=POINT_ALPHA,
             color=cell_type_colors[cell_type],
             linewidths=0,
@@ -284,19 +308,20 @@ def plot_comparison(key):
         )
 
     # Highlight the top pair per axis for each cell type.
-    for axis_col in ("s1", "s2"):
-        top_pairs = all_df.loc[all_df.groupby("cell_type")[axis_col].idxmax()]
-        for _, row in top_pairs.iterrows():
-            ax.scatter(
-                row["s1"],
-                row["s2"],
-                s=POINT_SIZE_FOREGROUND,
-                marker="*",
-                color=cell_type_colors[row["cell_type"]],
-                edgecolors="black",
-                linewidths=0.5,
-                zorder=5,
-            )
+    if not COMPARISONS[key].get("hide_stars", False):
+        for axis_col in ("s1", "s2"):
+            top_pairs = all_df.loc[all_df.groupby("cell_type")[axis_col].idxmax()]
+            for _, row in top_pairs.iterrows():
+                ax.scatter(
+                    row["s1"],
+                    row["s2"],
+                    s=POINT_SIZE_FOREGROUND,
+                    marker="*",
+                    color=cell_type_colors[row["cell_type"]],
+                    edgecolors="black",
+                    linewidths=0.5,
+                    zorder=5,
+                )
 
     if DISP_LEGEND:
         handles = [
@@ -397,18 +422,9 @@ print_spearman("kl_selec")
 #| label: fig-scan-comp-kl-selec-treg
 plot_comparison("kl_selec_treg")
 ```
-
-```{python}
-print_spearman("kl_selec_treg")
-```
-
 ```{python}
 #| label: fig-scan-comp-emd-selec-cd8tcm
 plot_comparison("emd_selec_cd8tcm")
-```
-
-```{python}
-print_spearman("emd_selec_cd8tcm")
 ```
 
 ```{python}
@@ -417,5 +433,11 @@ plot_comparison("emd_selec_pdc")
 ```
 
 ```{python}
-print_spearman("emd_selec_pdc")
+#| label: fig-scan-comp-selec-selec-highval
+plot_comparison("selec_selec-highval")
+```
+
+```{python}
+#| label: fig-scan-comp-selec-selec-mixval
+plot_comparison("selec_selec-mixval")
 ```

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -290,11 +290,7 @@ def build_comparison(metric_a, metric_b, cell_types, axis_norm, stack_order=None
         all_df["s2"] = all_df["s2"].rank(method="average")
 
     suffix = {"none": "", "z-score": " (z-score)", "rank": " (rank)"}[axis_norm]
-    # Looked up from the project-wide canonical CELL_TYPE_COLORS (see
-    # bicytok.figure_styles) rather than resampled per comparison, so a given cell
-    # type is always the same color regardless of which/how-many cell types this
-    # particular comparison happens to include (a single-cell-type comparison like
-    # "kl_selec_treg" previously always drew whatever color index 0 was).
+
     cell_type_colors = {ct: CELL_TYPE_COLORS[ct] for ct in cell_types}
     return {
         "df": all_df,
@@ -426,13 +422,11 @@ def print_spearman(key):
     print(pd.DataFrame(rows).to_string(index=False))
 ```
 
+## Pairwise metric comparisons with Spearman correlation
+
 ```{python}
 #| label: fig-scan-comp-emd-kl
 plot_comparison("emd_kl")
-```
-
-```{python}
-print_spearman("emd_kl")
 ```
 
 ```{python}
@@ -441,22 +435,26 @@ plot_comparison("emd_selec")
 ```
 
 ```{python}
-print_spearman("emd_selec")
-```
-
-```{python}
 #| label: fig-scan-comp-kl-selec
 plot_comparison("kl_selec")
 ```
 
 ```{python}
+print("\nEMD vs KL divergence Spearman correlation:")
+print_spearman("emd_kl")
+print("\nEMD vs selectivity Spearman correlation:")
+print_spearman("emd_selec")
+print("\nKL divergence vs selectivity Spearman correlation:")
 print_spearman("kl_selec")
 ```
+
+## Cell-type--specific comparisons
 
 ```{python}
 #| label: fig-scan-comp-kl-selec-treg
 plot_comparison("kl_selec_treg")
 ```
+
 ```{python}
 #| label: fig-scan-comp-emd-selec-cd8tcm
 plot_comparison("emd_selec_cd8tcm")
@@ -466,6 +464,8 @@ plot_comparison("emd_selec_cd8tcm")
 #| label: fig-scan-comp-emd-selec-pdc
 plot_comparison("emd_selec_pdc")
 ```
+
+## Low--high valency selectivity comparisons and legend
 
 ```{python}
 #| label: fig-scan-comp-selec-selec-highval
@@ -480,10 +480,6 @@ plot_comparison("selec_selec-mixval")
 ```{python}
 #| label: fig-scan-comp-celltype-legend
 #| fig-cap: "Shared legend for the cell-type-colored comparison scatter plots above"
-# Detached legend, mirroring suppfig-scan-outliers-legend and fig-celltype-legend
-# (scan_kxstar_bounds.qmd): every "all cell types" comparison above uses the same
-# canonical CELL_TYPE_COLORS mapping and omits its own legend, so this one legend
-# covers all of them and can be positioned independently (e.g. in Illustrator).
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -3,26 +3,46 @@ title: "Receptor Scan Metric Comparison Scatter Plots"
 ---
 
 # Summary
-Compares the three selectivity predictors — binding-model selectivity, EMD, and KL
-divergence — against one another across target cell types. Following the pattern in
-`scan_marker_overlap.qmd`, one binding-model scan and one distance-metric scan are
-supplied up front; the relevant metric columns are pulled from each based on their
-`.yaml` scan type. Three panels are produced, one per pairwise comparison:
-KL vs EMD, KL vs selectivity, and EMD vs selectivity. In each panel every receptor
-pair appears once per cell type as a point colored by cell type, with the
-top-scoring pair per axis highlighted with a star.
+Compares scan metrics (binding-model selectivity, EMD, KL divergence, or any numeric
+column from a scan CSV) against one another, one pairwise scatter per user-specified
+comparison. Each named entry in `COMPARISONS` picks two metrics from `METRICS` and a set
+of target cell types (`"all"` for the intersection of cell types present in both metrics'
+scans). In each panel every receptor pair appears once per cell type as a point colored by
+cell type, with the top-scoring pair per axis highlighted with a star.
+
+When a comparison involves the `Selectivity` metric and `FILTER_SELEC_BASIN` is enabled,
+a dashed line marks `SELEC_BASIN_CUTOFF` on the selectivity axis: points below it (the
+degenerate low-selectivity "basin" the binding model collapses to) stay on the plot but
+are excluded from the Spearman correlation.
+
+The analysis logic lives in `build_comparison`, and plotting/reporting in
+`plot_comparison` / `print_spearman`. The labeled cells are thin calls, so the same
+implementation drives several manuscript figures with different parameters.
 
 # Inputs
-- `SELEC_SCAN_PATH`: CSV from `run_selectivity_scan` (binding-model selectivity)
-- `KL_EMD_SCAN_PATH`: CSV from `run_KL_EMD_scan` (KL divergence and EMD)
-  Both must have matching `.yaml` files describing the scan type.
-- `TARG_CELL_TYPES`: list of target cell types to extract and overlay; `None` to use
-  the intersection of cell types present in both scans
+- `METRICS`: dict mapping display label -> `{"path": ..., "column": ..., "label": ...}`.
+  Each path must have a matching `.yaml` describing the scan type, which is validated
+  against the column (`Selectivity` -> `selectivity` scan; `EMD`/`KL_Divergence` ->
+  `KL_EMD` scan).
+- `COMPARISONS`: dict mapping key -> `{"metrics": (label_a, label_b), "cell_types": ...}`,
+  where `cell_types` is a list of target cell types or `"all"` to use the intersection of
+  cell types present in both metrics' scans. Two further keys are optional per comparison,
+  falling back to `AXIS_NORM` / `RASTERIZE_SCATTER` when omitted:
+  - `axis_norm`: `"none"`, `"z-score"`, or `"rank"`
+  - `rasterize`: rasterize the scatter points (keeps the star highlights vector); useful
+    for the large "all cell types" comparisons where SVG output would otherwise embed
+    tens of thousands of points
+- `FILTER_SELEC_BASIN` / `SELEC_BASIN_CUTOFF`: whether to exclude low-selectivity basin
+  points from Spearman correlation (raw `Selectivity` value, applied before any axis
+  normalization).
 
 # Outputs
-- **`fig-scan-comp-kl-emd`**: KL divergence vs EMD
-- **`fig-scan-comp-kl-selec`**: KL divergence vs binding-model selectivity
-- **`fig-scan-comp-emd-selec`**: EMD vs binding-model selectivity
+- **`fig-scan-comp-emd-kl`**: EMD vs KL divergence, all shared cell types
+- **`fig-scan-comp-emd-selec`**: EMD vs binding-model selectivity, all shared cell types
+- **`fig-scan-comp-kl-selec`**: KL divergence vs binding-model selectivity, all shared cell types
+- **`fig-scan-comp-kl-selec-treg`**: KL divergence vs binding-model selectivity, Treg only
+- **`fig-scan-comp-emd-selec-cd8tcm`**: EMD vs binding-model selectivity, CD8 TCM only
+- **`fig-scan-comp-emd-selec-pdc`**: EMD vs binding-model selectivity, pDC only
 
 Each panel: x = metric 1, y = metric 2, one color per cell type; all receptor pairs
 plotted as equal-sized points with the top pair per axis starred.
@@ -33,6 +53,7 @@ import os
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import yaml
 from scipy.stats import spearmanr
@@ -43,53 +64,87 @@ apply_style()
 
 # ── Parameters ────────────────────────────────────────────────────────────────
 
-FILTER_SELEC_BASIN = True
-AXIS_NORM = "rank"  # "none", "z-score", "rank"
+# Defaults for the per-comparison "axis_norm" / "rasterize" keys in COMPARISONS.
+AXIS_NORM = "none"  # "none", "z-score", "rank"
+RASTERIZE_SCATTER = False
+
 DISP_LEGEND = False
-
-
-SELEC_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv"
-KL_EMD_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_dist_scan_full_filt.csv"
-
-# List of target cell types to overlay; each is plotted in a distinct color.
-# Set to None to use the intersection of cell types present in both scans.
-TARG_CELL_TYPES: list[str] | None = None
 
 POINT_SIZE = 12
 POINT_ALPHA = 0.35
 
+# Exclude the degenerate low-selectivity "basin" from Spearman correlation for any
+# comparison involving the Selectivity metric (still shown on the plot, with a dashed
+# line marking the cutoff).
+FILTER_SELEC_BASIN = False
+SELEC_BASIN_CUTOFF = 0.51
 
-# ── Confirm scan types from YAML ───────────────────────────────────────────────
+_DATA = "/home/sama/receptor_sweep_data"
+SELEC_SCAN_PATH = f"{_DATA}/20260520_selec_scan_full.csv"
+KL_EMD_SCAN_PATH = f"{_DATA}/20260520_dist_scan_full_filt.csv"
+
+# Each metric: display label -> (scan path, CSV column, human-readable axis label).
+METRICS = {
+    "EMD": {"path": KL_EMD_SCAN_PATH, "column": "EMD", "label": "EMD"},
+    "KL": {
+        "path": KL_EMD_SCAN_PATH,
+        "column": "KL_Divergence",
+        "label": "KL divergence",
+    },
+    "Selectivity": {
+        "path": SELEC_SCAN_PATH,
+        "column": "Selectivity",
+        "label": "Binding model selectivity",
+    },
+}
+
+# Each comparison: two metric labels drawn from METRICS, and target cell types
+# ("all" = intersection of cell types present in both metrics' scans).
+COMPARISONS = {
+    "emd_kl": dict(metrics=("EMD", "KL"), cell_types="all", rasterize=True),
+    "emd_selec": dict(metrics=("Selectivity", "EMD"), cell_types="all", rasterize=True),
+    "kl_selec": dict(metrics=("Selectivity", "KL"), cell_types="all", rasterize=True),
+    "kl_selec_treg": dict(metrics=("Selectivity", "KL"), cell_types=["Treg"]),
+    "emd_selec_cd8tcm": dict(metrics=("Selectivity", "EMD"), cell_types=["CD8 TCM"]),
+    "emd_selec_pdc": dict(metrics=("Selectivity", "EMD"), cell_types=["pDC"]),
+}
+
+
+# ── CSV cache (a single file may back several metrics / comparisons) ───────────
+_CSV_CACHE = {}
+
+
+def _read_csv_cached(path):
+    if path not in _CSV_CACHE:
+        _CSV_CACHE[path] = pd.read_csv(path)
+    return _CSV_CACHE[path]
+
+
+# ── Confirm scan types from YAML ────────────────────────────────────────────────
 def _scan_type(scan_path):
     yaml_path = os.path.splitext(scan_path)[0] + ".yaml"
     with open(yaml_path) as f:
         return yaml.safe_load(f)["scan_type"]
 
 
-assert _scan_type(SELEC_SCAN_PATH) == "selectivity", (
-    f"{SELEC_SCAN_PATH} is not a selectivity scan"
-)
-assert _scan_type(KL_EMD_SCAN_PATH) == "KL_EMD", (
-    f"{KL_EMD_SCAN_PATH} is not a KL/EMD scan"
-)
-
-# Each metric: (scan path, CSV column, human-readable label)
-METRIC_SELEC = (SELEC_SCAN_PATH, "Selectivity", "Binding model selectivity")
-METRIC_KL = (KL_EMD_SCAN_PATH, "KL_Divergence", "KL divergence")
-METRIC_EMD = (KL_EMD_SCAN_PATH, "EMD", "EMD")
-
-# The three pairwise comparisons, keyed for embedding.
-COMPARISONS = {
-    "kl_emd": (METRIC_KL, METRIC_EMD),
-    "kl_selec": (METRIC_KL, METRIC_SELEC),
-    "emd_selec": (METRIC_EMD, METRIC_SELEC),
+_SCAN_TYPE_FOR_COLUMN = {
+    "Selectivity": "selectivity",
+    "EMD": "KL_EMD",
+    "KL_Divergence": "KL_EMD",
 }
 
+for _label, _info in METRICS.items():
+    _expected = _SCAN_TYPE_FOR_COLUMN[_info["column"]]
+    _actual = _scan_type(_info["path"])
+    assert _actual == _expected, (
+        f"{_info['path']} is a {_actual!r} scan, expected {_expected!r} "
+        f"for metric {_label!r} (column {_info['column']!r})"
+    )
 
-# ── Load scans ────────────────────────────────────────────────────────────────
+
 def load_scan_flat(path, metric_col, cell_type):
     """Return DataFrame with columns rec1, rec2, metric for the given cell type."""
-    raw = pd.read_csv(path)
+    raw = _read_csv_cached(path)
     assert cell_type in raw["Cell_Type"].values, f"{cell_type!r} not found in {path}"
     assert metric_col in raw.columns, f"{metric_col!r} not a column in {path}"
     sub = raw[raw["Cell_Type"] == cell_type][
@@ -100,28 +155,40 @@ def load_scan_flat(path, metric_col, cell_type):
     ).reset_index(drop=True)
 
 
-# ── Resolve cell types ────────────────────────────────────────────────────────
-if TARG_CELL_TYPES is None:
-    ct1 = set(pd.read_csv(SELEC_SCAN_PATH)["Cell_Type"].unique())
-    ct2 = set(pd.read_csv(KL_EMD_SCAN_PATH)["Cell_Type"].unique())
-    TARG_CELL_TYPES = sorted(ct1 & ct2)
+def resolve_cell_types(path_a, path_b, cell_types):
+    """Return the requested cell types, or the intersection of both scans' if "all"."""
+    if cell_types == "all":
+        ct_a = set(_read_csv_cached(path_a)["Cell_Type"].unique())
+        ct_b = set(_read_csv_cached(path_b)["Cell_Type"].unique())
+        return sorted(ct_a & ct_b)
+    return list(cell_types)
 
 
-def build_comparison(metric_1, metric_2, cell_types, axis_norm):
+def _selec_basin_threshold(raw_series, axis_norm):
+    """Map SELEC_BASIN_CUTOFF (raw Selectivity units) into the axis-normalized space."""
+    if axis_norm == "z-score":
+        return (SELEC_BASIN_CUTOFF - raw_series.mean()) / (raw_series.std() + 1e-9)
+    if axis_norm == "rank":
+        return int(np.searchsorted(np.sort(raw_series.values), SELEC_BASIN_CUTOFF))
+    return SELEC_BASIN_CUTOFF
+
+
+def build_comparison(metric_a, metric_b, cell_types, axis_norm):
     """Merge two metrics per cell type and apply global axis normalization.
 
-    Returns (df, axis_1_label, axis_2_label) where df has columns
-    rec1, rec2, s1, s2, cell_type.
+    Returns a dict with the merged long-form DataFrame, the resolved cell types, a
+    color per cell type, the axis labels, and (if `FILTER_SELEC_BASIN` applies) the
+    selectivity-basin threshold in the normalized axis' units.
     """
-    path1, col1, label1 = metric_1
-    path2, col2, label2 = metric_2
+    info_a, info_b = METRICS[metric_a], METRICS[metric_b]
+    cell_types = resolve_cell_types(info_a["path"], info_b["path"], cell_types)
 
     ct_dfs = {}
     for cell_type in cell_types:
-        scan1 = load_scan_flat(path1, col1, cell_type)
-        scan2 = load_scan_flat(path2, col2, cell_type)
+        scan_a = load_scan_flat(info_a["path"], info_a["column"], cell_type)
+        scan_b = load_scan_flat(info_b["path"], info_b["column"], cell_type)
         merged = (
-            pd.merge(scan1, scan2, on=["rec1", "rec2"], suffixes=("_1", "_2"))
+            pd.merge(scan_a, scan_b, on=["rec1", "rec2"], suffixes=("_1", "_2"))
             .rename(columns={"metric_1": "s1", "metric_2": "s2"})
             .dropna(subset=["s1", "s2"])
         )
@@ -131,6 +198,23 @@ def build_comparison(metric_1, metric_2, cell_types, axis_norm):
 
     # Normalize globally across all cell types so panels are comparable.
     all_df = pd.concat(ct_dfs.values(), ignore_index=True)
+
+    # Selectivity-basin mask, computed on raw values before normalization. At most one
+    # axis is ever the Selectivity metric, since a comparison is always between two
+    # distinct metrics.
+    selec_axis = None
+    if info_a["column"] == "Selectivity":
+        selec_axis = "s1"
+    elif info_b["column"] == "Selectivity":
+        selec_axis = "s2"
+
+    thresholds = {"s1": None, "s2": None}
+    if FILTER_SELEC_BASIN and selec_axis is not None:
+        all_df["above_basin"] = all_df[selec_axis] >= SELEC_BASIN_CUTOFF
+        thresholds[selec_axis] = _selec_basin_threshold(all_df[selec_axis], axis_norm)
+    else:
+        all_df["above_basin"] = True
+
     if axis_norm == "z-score":
         all_df["s1"] = (all_df["s1"] - all_df["s1"].mean()) / (
             all_df["s1"].std() + 1e-9
@@ -143,32 +227,44 @@ def build_comparison(metric_1, metric_2, cell_types, axis_norm):
         all_df["s2"] = all_df["s2"].rank(method="average")
 
     suffix = {"none": "", "z-score": " (z-score)", "rank": " (rank)"}[axis_norm]
-    return all_df, label1 + suffix, label2 + suffix
-
-
-# Precompute all three comparisons up front.
-comparison_data = {
-    key: build_comparison(m1, m2, TARG_CELL_TYPES, AXIS_NORM)
-    for key, (m1, m2) in COMPARISONS.items()
-}
-
-# ── Shared cell-type color map ─────────────────────────────────────────────────
-cell_type_colors = dict(
-    zip(
-        TARG_CELL_TYPES,
-        categorical_colors(len(TARG_CELL_TYPES), cmap_name=CMAPS["categorical_large"]),
-        strict=True,
+    cell_type_colors = dict(
+        zip(
+            cell_types,
+            categorical_colors(len(cell_types), cmap_name=CMAPS["categorical_large"]),
+            strict=True,
+        )
     )
-)
+    return {
+        "df": all_df,
+        "cell_types": cell_types,
+        "cell_type_colors": cell_type_colors,
+        "axis_1_label": info_a["label"] + suffix,
+        "axis_2_label": info_b["label"] + suffix,
+        "threshold_1": thresholds["s1"],
+        "threshold_2": thresholds["s2"],
+    }
+
+
+# Precompute every comparison up front; labeled cells below are thin plot calls.
+comparison_data = {
+    key: build_comparison(
+        *cfg["metrics"], cfg["cell_types"], cfg.get("axis_norm", AXIS_NORM)
+    )
+    for key, cfg in COMPARISONS.items()
+}
 
 
 def plot_comparison(key):
     """Scatter one pairwise metric comparison, overlaying all cell types."""
-    all_df, axis_1_label, axis_2_label = comparison_data[key]
+    res = comparison_data[key]
+    all_df = res["df"]
+    cell_types = res["cell_types"]
+    cell_type_colors = res["cell_type_colors"]
+    rasterize = COMPARISONS[key].get("rasterize", RASTERIZE_SCATTER)
 
     fig, ax = plt.subplots(figsize=FIGSIZE["square_scatter"])
 
-    for cell_type in TARG_CELL_TYPES:
+    for cell_type in cell_types:
         df = all_df[all_df["cell_type"] == cell_type]
         ax.scatter(
             df["s1"],
@@ -178,6 +274,7 @@ def plot_comparison(key):
             color=cell_type_colors[cell_type],
             linewidths=0,
             zorder=2,
+            rasterized=rasterize,
         )
 
     # Highlight the top pair per axis for each cell type.
@@ -206,7 +303,7 @@ def plot_comparison(key):
                 markersize=8,
                 label=ct,
             )
-            for ct in TARG_CELL_TYPES
+            for ct in cell_types
         ]
         handles.append(
             mlines.Line2D(
@@ -223,17 +320,31 @@ def plot_comparison(key):
         )
         ax.legend(handles=handles, title="Cell type")
 
-    ax.set_xlabel(axis_1_label)
-    ax.set_ylabel(axis_2_label)
+    if res["threshold_1"] is not None:
+        ax.axvline(
+            res["threshold_1"], color="gray", linestyle="--", linewidth=1, zorder=1
+        )
+    if res["threshold_2"] is not None:
+        ax.axhline(
+            res["threshold_2"], color="gray", linestyle="--", linewidth=1, zorder=1
+        )
+
+    ax.set_xlabel(res["axis_1_label"])
+    ax.set_ylabel(res["axis_2_label"])
     plt.tight_layout()
     plt.show()
 
 
 def print_spearman(key):
-    """Print Spearman correlation per cell type and overall for one comparison."""
-    all_df, axis_1_label, axis_2_label = comparison_data[key]
+    """Print Spearman correlation per cell type and overall for one comparison.
+
+    Excludes selectivity-basin points (see `FILTER_SELEC_BASIN`) from the correlation;
+    this has no effect when the comparison doesn't involve the Selectivity metric.
+    """
+    res = comparison_data[key]
+    all_df = res["df"][res["df"]["above_basin"]]
     rows = []
-    for ct in TARG_CELL_TYPES:
+    for ct in res["cell_types"]:
         sub = all_df[all_df["cell_type"] == ct]
         r, p = spearmanr(sub["s1"], sub["s2"])
         rows.append({"Cell Type": ct, "Spearman r": round(r, 4), "p-value": f"{p:.2e}"})
@@ -245,17 +356,26 @@ def print_spearman(key):
             "p-value": f"{overall_p:.2e}",
         }
     )
-    print(f"Spearman correlation: {axis_1_label} vs. {axis_2_label}\n")
+    print(f"Spearman correlation: {res['axis_1_label']} vs. {res['axis_2_label']}\n")
     print(pd.DataFrame(rows).to_string(index=False))
 ```
 
 ```{python}
-#| label: fig-scan-comp-kl-emd
-plot_comparison("kl_emd")
+#| label: fig-scan-comp-emd-kl
+plot_comparison("emd_kl")
 ```
 
 ```{python}
-print_spearman("kl_emd")
+print_spearman("emd_kl")
+```
+
+```{python}
+#| label: fig-scan-comp-emd-selec
+plot_comparison("emd_selec")
+```
+
+```{python}
+print_spearman("emd_selec")
 ```
 
 ```{python}
@@ -268,10 +388,28 @@ print_spearman("kl_selec")
 ```
 
 ```{python}
-#| label: fig-scan-comp-emd-selec
-plot_comparison("emd_selec")
+#| label: fig-scan-comp-kl-selec-treg
+plot_comparison("kl_selec_treg")
 ```
 
 ```{python}
-print_spearman("emd_selec")
+print_spearman("kl_selec_treg")
+```
+
+```{python}
+#| label: fig-scan-comp-emd-selec-cd8tcm
+plot_comparison("emd_selec_cd8tcm")
+```
+
+```{python}
+print_spearman("emd_selec_cd8tcm")
+```
+
+```{python}
+#| label: fig-scan-comp-emd-selec-pdc
+plot_comparison("emd_selec_pdc")
+```
+
+```{python}
+print_spearman("emd_selec_pdc")
 ```

--- a/figures/scanning_analyses/scan_comparison_scatter.qmd
+++ b/figures/scanning_analyses/scan_comparison_scatter.qmd
@@ -32,6 +32,10 @@ implementation drives several manuscript figures with different parameters.
   - `rasterize`: rasterize the scatter points (keeps the star highlights vector); useful
     for the large "all cell types" comparisons where SVG output would otherwise embed
     tens of thousands of points
+  - `stack_order`: list of cell types to draw last (i.e. on top), in the given order.
+    All points share one `zorder`, so draw order alone decides which cell type's color
+    wins in dense overlaps; cell types not listed keep their existing relative order
+    and are drawn first (on the bottom).
 - `FILTER_SELEC_BASIN` / `SELEC_BASIN_CUTOFF`: whether to exclude low-selectivity basin
   points from Spearman correlation (raw `Selectivity` value, applied before any axis
   normalization).
@@ -137,10 +141,17 @@ COMPARISONS = {
     "emd_selec_cd8tcm": dict(metrics=("Selectivity", "EMD"), cell_types=["CD8 TCM"]),
     "emd_selec_pdc": dict(metrics=("Selectivity", "EMD"), cell_types=["pDC"]),
     "selec_selec-highval": dict(
-        metrics=("Selectivity monoval", "Selectivity bival"), cell_types="all", rasterize=True, hide_stars=True
+        metrics=("Selectivity monoval", "Selectivity bival"),
+        cell_types="all",
+        rasterize=True,
+        hide_stars=True,
+        stack_order=["ASDC", "B naive", "dnT", "HSPC"],
     ),
     "selec_selec-mixval": dict(
-        metrics=("Selectivity monoval", "Selectivity mix-val"), cell_types="all", rasterize=True, hide_stars=True
+        metrics=("Selectivity monoval", "Selectivity mix-val"),
+        cell_types="all",
+        rasterize=True,
+        hide_stars=True,
     ),
 }
 
@@ -199,6 +210,21 @@ def resolve_cell_types(path_a, path_b, cell_types):
     return list(cell_types)
 
 
+def order_by_stack_priority(cell_types, stack_order):
+    """Reorders cell_types so entries in stack_order are drawn last.
+
+    Every cell type's points share one zorder, so draw order alone decides which
+    cell type's color wins in dense overlaps — last drawn sits visually on top.
+    Cell types not in stack_order keep their existing relative order, drawn first
+    (on the bottom).
+    """
+    if not stack_order:
+        return cell_types
+    priority = [ct for ct in stack_order if ct in cell_types]
+    rest = [ct for ct in cell_types if ct not in priority]
+    return rest + priority
+
+
 def _selec_basin_threshold(raw_series, axis_norm):
     """Map SELEC_BASIN_CUTOFF (raw Selectivity units) into the axis-normalized space."""
     if axis_norm == "z-score":
@@ -208,15 +234,17 @@ def _selec_basin_threshold(raw_series, axis_norm):
     return SELEC_BASIN_CUTOFF
 
 
-def build_comparison(metric_a, metric_b, cell_types, axis_norm):
+def build_comparison(metric_a, metric_b, cell_types, axis_norm, stack_order=None):
     """Merge two metrics per cell type and apply global axis normalization.
 
-    Returns a dict with the merged long-form DataFrame, the resolved cell types, a
-    color per cell type, the axis labels, and (if `FILTER_SELEC_BASIN` applies) the
-    selectivity-basin threshold in the normalized axis' units.
+    Returns a dict with the merged long-form DataFrame, the resolved cell types
+    (ordered per `stack_order`; see COMPARISONS docs above), a color per cell type,
+    the axis labels, and (if `FILTER_SELEC_BASIN` applies) the selectivity-basin
+    threshold in the normalized axis' units.
     """
     info_a, info_b = METRICS[metric_a], METRICS[metric_b]
     cell_types = resolve_cell_types(info_a["path"], info_b["path"], cell_types)
+    cell_types = order_by_stack_priority(cell_types, stack_order)
 
     ct_dfs = {}
     for cell_type in cell_types:
@@ -282,7 +310,10 @@ def build_comparison(metric_a, metric_b, cell_types, axis_norm):
 # Precompute every comparison up front; labeled cells below are thin plot calls.
 comparison_data = {
     key: build_comparison(
-        *cfg["metrics"], cfg["cell_types"], cfg.get("axis_norm", AXIS_NORM)
+        *cfg["metrics"],
+        cfg["cell_types"],
+        cfg.get("axis_norm", AXIS_NORM),
+        cfg.get("stack_order"),
     )
     for key, cfg in COMPARISONS.items()
 }

--- a/figures/scanning_analyses/scan_heatmaps.qmd
+++ b/figures/scanning_analyses/scan_heatmaps.qmd
@@ -28,7 +28,7 @@ import numpy as np
 import seaborn as sns
 import yaml
 
-from figures.scanning_analyses.scan_runners import (
+from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -705,7 +705,7 @@ _celltype_legend_handles = [
     mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
     for ct in ALL_CELL_TYPES
 ]
-standalone_legend_figure(_celltype_legend_handles, ALL_CELL_TYPES, title="Cell type")
+standalone_legend_figure(_celltype_legend_handles, ALL_CELL_TYPES, ncol=2, title="Cell type")
 plt.show()
 ```
 

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -5,30 +5,37 @@ title: "Kx* Upper-Bound Effect on Selectivity Scans"
 # Summary
 Investigates why selectivity scans yield markedly different synergy depending on the upper bound imposed on Kx* during affinity optimization (see `scan_synergy.qmd`). A scan with an upper bound of 1e-5 gives widespread synergy, while an otherwise-identical scan with an upper bound of 1e-9 exhibits limited, low-gain synergy.
 
-This figure compares the distributions of all binding-model outputs across two (or more) selectivity scans. Each optimization returns, per receptor pair per cell type, a single log10(Kx*), one monomer affinity per receptor (signal + two targets), and a selectivity value. Four panels aggregate those outputs (and a derived synergy gain) over all successfully optimized pairs:
+A curated set of single-panel manuscript figures (`NEW_ANALYSES`) leads the file: each entry picks one pre-built comparison shape (an x/y axis pairing with its reference lines and limits), one scan to draw from, and whether points are colored by log2 selectivity gain or by cell type. `plot_new_analysis(key)` renders one entry as a standalone figure.
+
+After that, four panels aggregate every binding-model output (and a derived synergy gain) over all successfully optimized pairs, across the two `ACTIVE_SCANS`:
 
 1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked. When a large fraction of pairs optimize to Kx* above the tighter bound, that bound pins them at the wall, compressing the high-Kx* population and plausibly suppressing synergy.
 2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs are excluded here because the second target receptor is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
 3. **Selectivity distribution** — optimal selectivity, targ / (targ + off-targ), on a log density axis to reveal the high-selectivity tail above the ~0.5 no-selectivity floor.
 4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy (the pair beats either receptor alone). The signal receptor is excluded here, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
 
-A consolidated scatter grid (`fig-scatter-grid`) gathers every per-pair scatter into one figure: rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. This one figure therefore answers whether the high-Kx* pairs are the selective, synergistic ones; whether that population is dominated by degenerate near-floor pairs; how affinity compensates for capped Kx*; and where the constrained pairs end up. Points are rasterized (~276k per panel).
+A reference-only consolidated scatter grid (`fig-scatter-grid`) follows, gathering every per-pair scatter into one figure: rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. Points are rasterized (~276k per panel). This grid is kept as a diagnostic reference; it does not include the `NEW_ANALYSES` comparisons above.
 
-`fig-scatter-grid-celltype` repeats the same grid with points colored by cell type instead of gain, exposing which cell types occupy which regions of these spaces.
-
-A co-pinning flow panel (`fig-copinning`) labels each pair by whether it is pinned at its Kx* upper bound and whether a target arm sits at the affinity ceiling (four categories: both interior, aff ceiling only, Kx* pinned only, doubly pinned). Pairs are matched across scans and an alluvial diagram shows how the loose-bound categories redistribute under the tight bound — revealing which pool each constrained category is pulled from.
+Finally, a co-pinning flow panel (`fig-copinning`) labels each pair by whether it is pinned at its Kx* upper bound and whether a target arm sits at the affinity ceiling (four categories: both interior, aff ceiling only, Kx* pinned only, doubly pinned). Pairs are matched across scans and an alluvial diagram shows how the loose-bound categories redistribute under the tight bound — revealing which pool each constrained category is pulled from.
 
 # Inputs
-- `SCANS`: list of selectivity scans to compare, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory.
+- `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory. `SCANS` includes scans beyond the two analyzed by the older figures (e.g. the high-valency scans) — see `ACTIVE_SCAN_LABELS`; the remaining entries are commented-out alternate scan configs (signal-receptor, normalization, filter-strength variants) kept for reference.
+- `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` (by label) analyzed by `fig-kxstar-dist`, `fig-affinity-dist`, `fig-selectivity-dist`, `fig-gain-dist`, and `fig-scatter-grid`. `NEW_ANALYSES` is not restricted to this subset — any scan in `SCANS` can be referenced by `scan_label`.
+- `NEW_ANALYSES`: dict of curated single-panel figures. Each entry has a `comparison` (a key into `COMPARISON_SHAPES`), a `scan_label` (any scan in `SCANS`), and a `color_by` of `"gain"` (log2 selectivity gain, colorbar, sized via `FIGSIZE["square_scatter_with_colorbar"]`) or `"cell_type"` (shared `CELL_TYPE_COLORS` mapping; legend omitted per panel, see `fig-celltype-legend`).
 - `AFFINITY_BOUNDS`: shared (min, max) affinity optimization bounds in log10(M), drawn as reference lines in the affinity panel.
 
 # Outputs
+- **`fig-sel-vs-kx-loose`**: Selectivity vs. optimal log10(Kx*), 1e-5 bound scan, colored by cell type. Shares its y-axis range (`SELEC_BOUNDS`) with `fig-sel-vs-targ1aff-loose` for side-by-side manuscript placement.
+- **`fig-sel-vs-targ1aff-loose`**: Selectivity vs. Target 1 affinity, 1e-5 bound scan, colored by cell type.
+- **`fig-gain-vs-sel-loose`**: log2 selectivity gain vs. Selectivity, 1e-5 bound scan.
+- **`fig-gain-vs-sel-bivalent`**: log2 selectivity gain vs. Selectivity, bivalent high-valency scan (in `SCANS` but outside `ACTIVE_SCAN_LABELS`; colored by its own gain via its self-referencing `gain_ref`).
+- **`fig-gain-vs-sel-mixedval`**: log2 selectivity gain vs. Selectivity, mixed-valency scan (in `SCANS` but outside `ACTIVE_SCAN_LABELS`; colored by its own gain).
+- **`fig-celltype-legend`**: shared legend mapping cell type to color for every `color_by="cell_type"` panel above, detached so it can be positioned independently (e.g. in Illustrator) rather than repeated per panel.
 - **`fig-kxstar-dist`**: overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked and the fraction of pairs pinned at that bound annotated
 - **`fig-affinity-dist`**: overlaid density histograms of optimal affinity, one subpanel per receptor (signal, target 1, target 2); diagonal pairs excluded
 - **`fig-selectivity-dist`**: overlaid log-density histograms of optimal selectivity
 - **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain (bispecific / max constituent monospecific); gain > 1 is synergy
-- **`fig-scatter-grid`**: rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
-- **`fig-scatter-grid-celltype`**: the same grid colored by cell type, showing where cell types sit in these spaces
+- **`fig-scatter-grid`** (reference/diagnostic): rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
 - **`fig-copinning`**: cross-scan alluvial flow of pairs between four constraint categories (Kx*-pinned × target-affinity-ceiling), showing where each tight-bound category is pulled from
 
 ```{python}
@@ -39,8 +46,25 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import yaml
+from matplotlib.colors import Normalize
+from matplotlib.patches import Patch
 
-# ── Parameters ────────────────────────────────────────────────────────────────
+from bicytok.figure_styles import (
+    CMAPS,
+    COLORBAR_FRACTION,
+    COLORBAR_PAD,
+    FIGSIZE,
+    FONT_SIZE_ANNOT,
+    FONT_SIZE_TITLE,
+    POINT_SIZE_XS,
+    POINT_SIZE_BACKGROUND,
+    apply_style,
+    categorical_colors,
+)
+
+apply_style()
+
+# ── Scan pools ──────────────────────────────────────────────────────────────────
 # Each scan's "gain_ref" names the scan (by label) whose per-pair gain colors this scan's points
 # in fig-scatter-grid: its own label uses its own gain; another scan's label maps that scan's gain
 # onto these coordinates (pointing the tight scan at the loose scan reveals where pairs get
@@ -57,28 +81,29 @@ SCANS = [
 
     # Tight Kx* bound scan
     {
-        "path": "/home/sama/receptor_sweep_data/20260720_selec_scan_rand42.csv",
+        "path": "/home/sama/receptor_sweep_data/20260720_selec_scan_rand42_prot1.csv",
         "label": "Kx* upper bound 1e-9",
         "kx_upper": -9.0,
         "color": "#CF4D6F",
         "gain_ref": "Kx* upper bound 1e-5",
     },
 
-    # High-valency scans
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260529_selec_scan_full_bival.csv",
-    #     "label": "Bivalent Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#4E9A06",
-    #     "gain_ref": "Bivalent Kx* upper bound 1e-5",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260608_selec_scan_full_mix-val.csv",
-    #     "label": "Mixed Valency Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#FF7F00",
-    #     "gain_ref": "Mixed ValencyKx* upper bound 1e-5",
-    # },
+    # High-valency scans. Not in ACTIVE_SCAN_LABELS below, so excluded from the old
+    # distribution/grid figures; available to NEW_ANALYSES via scan_label.
+    {
+        "path": "/home/sama/receptor_sweep_data/20260529_selec_scan_full_bival.csv",
+        "label": "Bivalent Kx* upper bound 1e-5",
+        "kx_upper": -5.0,
+        "color": "#4E9A06",
+        "gain_ref": "Bivalent Kx* upper bound 1e-5",
+    },
+    {
+        "path": "/home/sama/receptor_sweep_data/20260608_selec_scan_full_mix-val.csv",
+        "label": "Mixed Valency Kx* upper bound 1e-5",
+        "kx_upper": -5.0,
+        "color": "#FF7F00",
+        "gain_ref": "Mixed Valency Kx* upper bound 1e-5",
+    },
 
     # # Specified signal receptor scan
     # {
@@ -143,10 +168,17 @@ SCANS = [
     # },
 ]
 
+# Scans analyzed by fig-kxstar-dist, fig-affinity-dist, fig-selectivity-dist, fig-gain-dist,
+# and fig-scatter-grid. SCANS may hold other scans (e.g. the high-valency ones above) that are
+# loaded and available to NEW_ANALYSES by scan_label but excluded from these older figures.
+ACTIVE_SCAN_LABELS = ["Kx* upper bound 1e-5", "Kx* upper bound 1e-9"]
+ACTIVE_SCANS = [s for s in SCANS if s["label"] in ACTIVE_SCAN_LABELS]
+
 # True affinity optimization bounds, log10(M), used for pin/ceiling logic. AFFINITY_BOUNDS pads
 # these for display so points and bars sitting exactly at a bound are not clipped at the spine.
 AFFINITY_OPT_BOUNDS = (6.0, 12.0)
 AFFINITY_BOUNDS = (5.9, 12.1)
+SELEC_BOUNDS = (0.47, 1.02)  # pair selectivity display range, away from the ~0.5 no-selectivity floor
 
 # Affinity CSV columns mapped to their receptor role (order = subpanel order).
 AFF_COLS = {
@@ -159,16 +191,44 @@ AFF_COLS = {
 # containing the artificial signal receptor is not a genuine two-target combination.
 SIGNAL_REC_NAME = "Prototype_Signal_Receptor"
 
-# ── Font size constants (shared across panels) ────────────────────────────────
-FS_LABEL = 14
-FS_TICK = 12
-FS_LEGEND = 11
-FS_ANNOT = 10
-
 # Fraction pinned is counted within this log10 tolerance of the bound; a target affinity within
 # AFF_CEIL_EPS of the optimization ceiling counts as sitting "at the ceiling".
 PIN_TOL = 1e-2
 AFF_CEIL_EPS = 1e-2
+
+
+# ── Curated single-panel analyses (manuscript/SVG extraction) ──────────────────
+# Each entry renders one standalone panel via plot_new_analysis(key): "comparison" names a
+# shape in COMPARISON_SHAPES (x/y axes, reference lines, limits), "scan_label" names any scan
+# in SCANS (not just ACTIVE_SCANS), and "color_by" is "gain" (log2 selectivity gain, colorbar)
+# or "cell_type" (one color per Cell_Type, legend).
+NEW_ANALYSES = {
+    "sel_vs_kx_loose": dict(
+        comparison="sel_vs_kx_loose",
+        scan_label="Kx* upper bound 1e-5",
+        color_by="cell_type",
+    ),
+    "sel_vs_targ1aff_loose": dict(
+        comparison="sel_vs_targ1_aff",
+        scan_label="Kx* upper bound 1e-5",
+        color_by="cell_type",
+    ),
+    "gain_vs_sel_loose": dict(
+        comparison="gain_vs_sel",
+        scan_label="Kx* upper bound 1e-5",
+        color_by="gain",
+    ),
+    "gain_vs_sel_bivalent": dict(
+        comparison="gain_vs_sel",
+        scan_label="Bivalent Kx* upper bound 1e-5",
+        color_by="gain",
+    ),
+    "gain_vs_sel_mixedval": dict(
+        comparison="gain_vs_sel",
+        scan_label="Mixed Valency Kx* upper bound 1e-5",
+        color_by="gain",
+    ),
+}
 
 
 # ── Load binding-model outputs from each scan ─────────────────────────────────
@@ -248,201 +308,18 @@ def pair_key(df):
     return df["Cell_Type"].to_numpy() + "|" + recs[:, 0] + "|" + recs[:, 1]
 
 
-# ── Shared overlaid-histogram helper ──────────────────────────────────────────
-def overlay_hist(
-    ax,
-    data_by_scan,
-    bins,
-    scan_bounds=None,
-    annotate_pinned=False,
-    ref_lines=(),
-    logy=False,
-):
-    """Overlay per-scan density histograms of one output on ax.
-
-    scan_bounds: optional {scan label: bound value}, drawn as a dashed line in the
-        scan's color; with annotate_pinned, the fraction of pairs within PIN_TOL of
-        the bound is labeled.
-    ref_lines: x-values drawn as shared gray reference lines (e.g. affinity bounds).
-    logy: use a log-scaled density axis.
-    """
-    for scan in SCANS:
-        ax.hist(
-            data_by_scan[scan["label"]],
-            bins=bins,
-            density=False,
-            alpha=0.55,
-            color=scan["color"],
-            label=scan["label"],
-        )
-    if logy:
-        ax.set_yscale("log")
-    for x in ref_lines:
-        ax.axvline(x, color="0.45", ls=":", lw=1.0, zorder=2)
-    if scan_bounds:
-        y_top = ax.get_ylim()[1]
-        x_lo, x_hi = bins[0], bins[-1]
-        for scan in SCANS:
-            bound = scan_bounds.get(scan["label"])
-            if bound is None:
-                continue
-            ax.axvline(bound, color=scan["color"], ls="--", lw=1.5, zorder=3)
-            if annotate_pinned:
-                frac = np.mean(np.abs(data_by_scan[scan["label"]] - bound) < PIN_TOL)
-                near_right = bound > x_lo + 0.8 * (x_hi - x_lo)
-                ax.text(
-                    bound + (-0.1 if near_right else 0.1),
-                    y_top * 0.92,
-                    f"{frac:.0%} at bound",
-                    color=scan["color"],
-                    fontsize=FS_ANNOT,
-                    ha="right" if near_right else "left",
-                    va="top",
-                )
-    ax.tick_params(labelsize=FS_TICK)
-
-
-def overlay_figure(
-    data_by_scan, bins, xlabel, ylabel, legend_loc, xlim=None, **hist_kwargs
-):
-    """Single-axis overlaid-histogram figure: overlay per-scan histograms, then label and show.
-
-    xlim defaults to the bin span; pass it to override (e.g. clip the selectivity axis at 1).
-    hist_kwargs pass through to overlay_hist (scan_bounds, annotate_pinned, ref_lines, logy).
-    """
-    fig, ax = plt.subplots(figsize=(8, 5.5))
-    overlay_hist(ax, data_by_scan, bins, **hist_kwargs)
-    ax.set_xlim(*(xlim if xlim is not None else (bins[0], bins[-1])))
-    ax.set_xlabel(xlabel, fontsize=FS_LABEL)
-    ax.set_ylabel(ylabel, fontsize=FS_LABEL)
-    ax.legend(fontsize=FS_LEGEND, loc=legend_loc)
-    plt.tight_layout()
-    plt.show()
-```
-
-```{python}
-#| label: fig-kxstar-dist
-# ── Distribution of optimal Kx* across scans ──────────────────────────────────
-# Overlaid density histograms of optimal log10(Kx*). Histograms (not KDEs) are used so
-# the pile-up of pairs pinned at a scan's upper bound is preserved rather than smeared.
-# When a scan's bound sits below where many pairs would otherwise optimize, those pairs
-# stack against the wall, forming a spike at the bound.
-
-kx_by_scan = {lbl: df["Kx_star"].to_numpy() for lbl, df in scan_dfs.items()}
-
-all_kx = np.concatenate(list(kx_by_scan.values()))
-bins = np.arange(np.floor(all_kx.min()), np.ceil(all_kx.max()) + 0.2, 0.2)
-
-overlay_figure(
-    kx_by_scan,
-    bins,
-    "Optimal log10(Kx*)",
-    "Number of pairs",
-    "upper left",
-    scan_bounds={scan["label"]: scan["kx_upper"] for scan in SCANS},
-    annotate_pinned=True,
-)
-```
-
-```{python}
-#| label: fig-affinity-dist
-# ── Distributions of optimal affinities per receptor ──────────────────────────
-# One subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs
-# are excluded: those are modeled as a single target with combined valency, so the
-# second target receptor has valency 0 and its affinity is never optimized (it stays at
-# its initialization value). Reference lines mark the shared affinity bounds.
-
-off_diag_dfs = {
-    lbl: df[df["Receptor_1"] != df["Receptor_2"]] for lbl, df in scan_dfs.items()
-}
-aff_bins = np.arange(AFFINITY_BOUNDS[0], AFFINITY_BOUNDS[1] + 0.2, 0.2)
-
-fig, axes = plt.subplots(
-    1, len(AFF_COLS), figsize=(5 * len(AFF_COLS), 4.8), sharey=True
-)
-for ax, (col, title) in zip(axes, AFF_COLS.items(), strict=True):
-    data = {lbl: df[col].to_numpy() for lbl, df in off_diag_dfs.items()}
-    overlay_hist(ax, data, aff_bins, ref_lines=AFFINITY_BOUNDS)
-    ax.set_title(title, fontsize=FS_LABEL)
-    ax.set_xlim(*AFFINITY_BOUNDS)
-    ax.set_xlabel("Optimal affinity, log10(M)", fontsize=FS_LABEL)
-axes[0].set_ylabel("Number of pairs", fontsize=FS_LABEL)
-axes[0].legend(fontsize=FS_LEGEND, loc="upper right")
-plt.tight_layout()
-plt.show()
-```
-
-```{python}
-#| label: fig-selectivity-dist
-# ── Distribution of optimal selectivity across scans ──────────────────────────
-# Selectivity = targ / (targ + off-targ), bounded in (0, 1], structurally floored near
-# 0.5 (equal on/off-target binding, i.e. no selectivity). A log density axis reveals the
-# high-selectivity tail; a reference line marks the 0.5 floor.
-
-sel_by_scan = {lbl: df["Selectivity"].to_numpy() for lbl, df in scan_dfs.items()}
-
-all_sel = np.concatenate(list(sel_by_scan.values()))
-sel_bins = np.linspace(all_sel.min(), 1.0, 60)
-
-overlay_figure(
-    sel_by_scan,
-    sel_bins,
-    "Optimal selectivity, targ / (targ + off-targ)",
-    "Number of pairs (log scale)",
-    "upper right",
-    xlim=(sel_bins[0], 1.0),
-    ref_lines=(0.5,),
-    logy=True,
-)
-```
-
-```{python}
-#| label: fig-gain-dist
-# ── Distribution of per-pair selectivity gain (synergy) ───────────────────────
-# log2(gain) per pair, gain = bispecific / max(constituent monospecific). A log density
-# axis is essential: the bulk of pairs sit at gain ~= 1 (the optimizer falls back to the
-# better single receptor), so the scans differ only in the tails. The right tail (gain > 1)
-# is genuine synergy; the reference line at 0 marks gain = 1 (no synergy).
-
-gain_by_scan = {lbl: df["log2_gain"].to_numpy() for lbl, df in pair_dfs.items()}
-
-all_gain = np.concatenate(list(gain_by_scan.values()))
-gain_bins = np.linspace(all_gain.min(), all_gain.max(), 70)
-
-overlay_figure(
-    gain_by_scan,
-    gain_bins,
-    "log2 selectivity gain (pair / max monospecific)",
-    "Number of pairs (log scale)",
-    "upper left",
-    ref_lines=(0.0,),
-    logy=True,
-)
-```
-
-```{python}
-#| label: fig-scatter-grid
-# ── Consolidated scatter comparisons, colored by loose-bound synergy ──────────
-# One grid gathering every per-pair scatter: rows are comparisons, columns are scans (loose
-# bound left, tight bound right). The first four rows put each output on y vs. optimal
-# log10(Kx*) on x; the last three put log2 selectivity gain on y vs. an output on x. Every
-# panel uses the same coloring: all pairs in gray for context, with pairs that are synergistic
-# in that scan's reference scan (its "gain_ref") overlaid and colored by the reference scan's
-# log2 gain (strongest drawn last). Pointing the tight scan at the loose scan maps the loose-bound
-# gain onto the tight coordinates, so the tight-bound column shows exactly where the once-
-# synergistic pairs are trapped once Kx* is capped — pinned at the wall, driven to the affinity
-# ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales are shared
-# within a row (across scans), not down a column, so x and y labels are set per row.
-
-from matplotlib.colors import Normalize
-
+# ── Comparison shapes: x/y axes, reference lines, limits ──────────────────────
 SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
-SELEC_BOUNDS = (0.47, 1.02)
 GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
 KX_XLABEL = "Optimal log10(Kx*)"
 GAIN_YLABEL = "log2 selectivity gain"
 SELECTIVITY_XLABEL = "Pair selectivity"
-PANEL_W, PANEL_H = 4.3, 3.0
+
+# ~276k points per panel in the bulk grid: far denser than the shared point-size constants
+# assume (tuned for scatter plots with far fewer points), so these panels keep their own
+# smaller sizes to stay legible rather than rendering as a solid blob.
+GRID_POINT_SIZE_BG = 3
+GRID_POINT_SIZE_FG = 5
 
 
 def _vs_kxstar(ykey):
@@ -469,11 +346,21 @@ def _gain_vs(xkey):
 
     return get
 
+
 def _vs_selectivity(ykey):
     """Comparison getter: an output on y against selectivity on x."""
 
     def get(sd, cvals):
         return sd["sel"], sd[ykey], cvals
+
+    return get
+
+
+def _sel_vs(xkey):
+    """Comparison getter: selectivity on y against an output on x."""
+
+    def get(sd, cvals):
+        return sd[xkey], sd["sel"], cvals
 
     return get
 
@@ -494,37 +381,37 @@ def _row(get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vl
     )
 
 
-COMPARISONS = [
-    _row(_vs_kxstar("sel"), KX_XLABEL, "Selectivity", yrefs=(0.5,), kx_vline=True),
-    _row(
+COMPARISON_SHAPES = {
+    "sel_vs_kx": _row(_vs_kxstar("sel"), KX_XLABEL, "Selectivity", yrefs=(0.5,), kx_vline=True),
+    "sig_aff_vs_kx": _row(
         _vs_kxstar("aff0"),
         KX_XLABEL,
         "Signal aff, log10(M)",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    _row(
+    "targ1_aff_vs_kx": _row(
         _vs_kxstar("aff1"),
         KX_XLABEL,
         "Target 1 aff, log10(M)",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    _row(
+    "targ2_aff_vs_kx": _row(
         _vs_kxstar("aff2"),
         KX_XLABEL,
         "Target 2 aff, log10(M)",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    _row(
+    "gain_vs_sel": _row(
         _gain_vs("sel"),
         SELECTIVITY_XLABEL,
         GAIN_YLABEL,
         xrefs=(SELEC_FLOOR,),
         yrefs=(0.0,),
     ),
-    _row(
+    "sig_aff_vs_sel": _row(
         _vs_selectivity("aff0"),
         SELECTIVITY_XLABEL,
         "Signal aff, log10(M)",
@@ -533,7 +420,7 @@ COMPARISONS = [
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    _row(
+    "targ1_aff_vs_sel": _row(
         _vs_selectivity("aff1"),
         SELECTIVITY_XLABEL,
         "Target 1 aff, log10(M)",
@@ -542,7 +429,7 @@ COMPARISONS = [
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    _row(
+    "targ2_aff_vs_sel": _row(
         _vs_selectivity("aff2"),
         SELECTIVITY_XLABEL,
         "Target 2 aff, log10(M)",
@@ -552,6 +439,38 @@ COMPARISONS = [
         kx_vline=True,
     ),
 
+    # Used only by NEW_ANALYSES single-panel extracts, not the bulk reference grid (see
+    # GRID_COMPARISON_KEYS): sel_vs_kx_loose fixes the y-axis to SELEC_BOUNDS (rather than
+    # auto-scaling) so it matches sel_vs_targ1_aff's y-axis for side-by-side placement.
+    "sel_vs_kx_loose": _row(
+        _vs_kxstar("sel"),
+        KX_XLABEL,
+        "Selectivity",
+        ylim=SELEC_BOUNDS,
+        yrefs=(0.5,),
+        kx_vline=True,
+    ),
+    "sel_vs_targ1_aff": _row(
+        _sel_vs("aff1"),
+        "Target 1 aff, log10(M)",
+        "Selectivity",
+        xlim=AFFINITY_BOUNDS,
+        ylim=SELEC_BOUNDS,
+        yrefs=(0.5,),
+    ),
+}
+
+# The bulk reference grid (fig-scatter-grid) renders exactly these 8 original comparisons;
+# NEW_ANALYSES entries reference COMPARISON_SHAPES directly and never touch this list.
+GRID_COMPARISON_KEYS = [
+    "sel_vs_kx",
+    "sig_aff_vs_kx",
+    "targ1_aff_vs_kx",
+    "targ2_aff_vs_kx",
+    "gain_vs_sel",
+    "sig_aff_vs_sel",
+    "targ1_aff_vs_sel",
+    "targ2_aff_vs_sel",
 ]
 
 
@@ -566,63 +485,6 @@ def scan_base_arrays(scan):
         "aff2": df["Affinity_Receptor_2"].to_numpy(),
         "log2_gain": df["log2_gain"].to_numpy(),
     }
-
-
-def _sync_row(axes_row):
-    """Put every panel in a comparison row on a shared x/y scale (union of the columns)."""
-    xlims = [a.get_xlim() for a in axes_row]
-    ylims = [a.get_ylim() for a in axes_row]
-    x0, x1 = min(a for a, _ in xlims), max(b for _, b in xlims)
-    y0, y1 = min(a for a, _ in ylims), max(b for _, b in ylims)
-    for a in axes_row:
-        a.set_xlim(x0, x1)
-        a.set_ylim(y0, y1)
-
-
-def build_comparison_grid(scan_colors, draw_points):
-    """Draw the comparison grid (rows = comparisons, cols = scans).
-
-    scan_colors: {scan label: per-point color value aligned to pair_dfs[label]}.
-    draw_points: fn(ax, x, y, color_values) -> optional mappable (captured for a colorbar).
-    """
-    fig, axes = plt.subplots(
-        len(COMPARISONS),
-        len(SCANS),
-        figsize=(PANEL_W * len(SCANS), PANEL_H * len(COMPARISONS)),
-        squeeze=False,
-        layout="constrained",
-    )
-    mappable = None
-    for c, scan in enumerate(SCANS):
-        sd = scan_base_arrays(scan)
-        cbase = scan_colors[scan["label"]]
-        for r, comp in enumerate(COMPARISONS):
-            ax = axes[r, c]
-            x, y, cvals = comp["get"](sd, cbase)
-            drawn = draw_points(ax, x, y, cvals)
-            if drawn is not None:
-                mappable = drawn
-            for xv in comp["xrefs"]:
-                ax.axvline(xv, color="0.45", ls=":", lw=1.0, zorder=3)
-            for yv in comp["yrefs"]:
-                ax.axhline(yv, color="0.45", ls=":", lw=1.0, zorder=3)
-            if comp["kx_vline"] and scan["kx_upper"] is not None:
-                ax.axvline(
-                    scan["kx_upper"], color="0.3", ls="--", lw=1.0, zorder=3, alpha=0.5
-                )
-            if comp["xlim"] is not None:
-                ax.set_xlim(*comp["xlim"])
-            if comp["ylim"] is not None:
-                ax.set_ylim(*comp["ylim"])
-            ax.tick_params(labelsize=FS_TICK - 2)
-            if r == 0:
-                ax.set_title(scan["label"], fontsize=FS_LABEL)
-            if c == 0:
-                ax.set_ylabel(comp["ylabel"], fontsize=FS_LABEL - 1)
-            ax.set_xlabel(comp["xlabel"], fontsize=FS_LABEL - 1)
-    for row in axes:
-        _sync_row(row)
-    return fig, axes, mappable
 
 
 # Color every point by the gain of the scan named in that scan's "gain_ref": its own gain used
@@ -648,11 +510,34 @@ for scan in SCANS:
 
 gain_norm = Normalize(vmin=0, vmax=GAIN_COLOR_MAX)
 
+# Canonical cell-type -> color mapping, shared by every color_by="cell_type" NEW_ANALYSES
+# panel and the standalone fig-celltype-legend cell below, so a given cell type always gets
+# the same color regardless of which scan's panel it appears in (a per-panel local mapping
+# would assign colors by sorted position, which can point to different cell types across
+# panels whose present-cell-type sets differ slightly).
+ALL_CELL_TYPES = sorted(
+    set().union(*(df["Cell_Type"].unique() for df in pair_dfs.values()))
+)
+CELL_TYPE_COLORS = dict(
+    zip(
+        ALL_CELL_TYPES,
+        categorical_colors(len(ALL_CELL_TYPES), cmap_name=CMAPS["categorical_large"]),
+        strict=True,
+    )
+)
 
-def draw_gain_points(ax, x, y, cvals):
+
+def draw_gain_points(ax, x, y, cvals, point_size_bg=GRID_POINT_SIZE_BG, point_size_fg=GRID_POINT_SIZE_FG):
     """Gray context cloud plus a Reds overlay of the pairs synergistic in the reference scan."""
     ax.scatter(
-        x, y, s=3, alpha=0.4, color="0.82", linewidths=0, rasterized=True, zorder=1
+        x,
+        y,
+        s=point_size_bg,
+        alpha=0.4,
+        color="0.82",
+        linewidths=0,
+        rasterized=True,
+        zorder=1,
     )
     synergistic = (
         cvals > 0
@@ -664,7 +549,7 @@ def draw_gain_points(ax, x, y, cvals):
         c=cvals[synergistic][order],
         cmap="Reds",
         norm=gain_norm,
-        s=5,
+        s=point_size_fg,
         alpha=0.9,
         linewidths=0,
         rasterized=True,
@@ -672,76 +557,424 @@ def draw_gain_points(ax, x, y, cvals):
     )
 
 
-fig, axes, mappable = build_comparison_grid(scan_colors_gain, draw_gain_points)
-fig.colorbar(
-    mappable,
-    ax=axes.ravel().tolist(),
-    label="log2 selectivity gain, reference scan  (gray = none)",
-    fraction=0.03,
-    pad=0.02,
-)
-plt.show()
-```
-
-```{python}
-#| label: fig-scatter-grid-celltype
-# ── The same scatter grid, colored by cell type ───────────────────────────────
-# Identical layout to fig-scatter-grid (rows = comparisons, cols = scans), reusing its
-# machinery, but every pair is colored by its cell type instead of by gain. This exposes which
-# cell types occupy which regions — e.g. whether particular cell types drive the high-Kx*,
-# high-selectivity population or the affinity-ceiling band. With 31 overlapping cell types the
-# view is necessarily dense; it is meant for spotting per-cell-type structure, not exact counts.
-
-from matplotlib.patches import Patch
-
-CELL_TYPES = sorted(
-    set().union(*(pair_dfs[scan["label"]]["Cell_Type"].unique() for scan in SCANS))
-)
-# tab20 + tab20b together give enough distinct qualitative colors for all cell types.
-_qual_colors = list(plt.get_cmap("tab20").colors) + list(plt.get_cmap("tab20b").colors)
-CT_COLORS = _qual_colors[: len(CELL_TYPES)]
-ct_code = {ct: i for i, ct in enumerate(CELL_TYPES)}
-CT_COLOR_ARRAY = np.array(CT_COLORS)
-scan_colors_ct = {
-    scan["label"]: pair_dfs[scan["label"]]["Cell_Type"].map(ct_code).to_numpy()
-    for scan in SCANS
-}
-_ct_rng = np.random.default_rng(0)
-
-
-def draw_celltype_points(ax, x, y, codes):
-    """Scatter every pair colored by its cell type, draw order shuffled so no type dominates."""
-    perm = _ct_rng.permutation(len(x))
+def draw_celltype_points(ax, x, y, cell_types, point_size=GRID_POINT_SIZE_FG):
+    """Scatter colored by cell type via the shared CELL_TYPE_COLORS mapping, draw order
+    shuffled so no type visually dominates. See fig-celltype-legend for the legend.
+    """
+    rng = np.random.default_rng(0)
+    perm = rng.permutation(len(x))
+    point_colors = np.array([CELL_TYPE_COLORS[ct] for ct in cell_types])
     ax.scatter(
         x[perm],
         y[perm],
-        c=CT_COLOR_ARRAY[codes[perm]],
-        s=3,
-        alpha=0.5,
+        c=point_colors[perm],
+        s=point_size,
+        alpha=0.6,
         linewidths=0,
         rasterized=True,
     )
-    return None
 
 
-fig, axes, _ = build_comparison_grid(scan_colors_ct, draw_celltype_points)
-fig.legend(
-    handles=[
-        Patch(facecolor=CT_COLORS[i], label=CELL_TYPES[i])
-        for i in range(len(CELL_TYPES))
-    ],
-    loc="center left",
-    bbox_to_anchor=(1.0, 0.5),
-    ncol=1,
-    fontsize=FS_LEGEND - 2,
-    frameon=False,
-    title="Cell type",
-)
+def _draw_comparison_panel(
+    ax,
+    comp,
+    scan,
+    sd,
+    aux_vals,
+    color_by="gain",
+    point_size_bg=GRID_POINT_SIZE_BG,
+    point_size_fg=GRID_POINT_SIZE_FG,
+):
+    """Draw one comparison panel (one comparison x one scan) onto ax.
+
+    aux_vals: per-point color-driving values — log2 gain for color_by="gain" (continuous,
+    paired with a colorbar) or cell-type labels for color_by="cell_type" (categorical; see
+    the shared CELL_TYPE_COLORS mapping and fig-celltype-legend, not repeated per panel).
+    point_size_bg/point_size_fg default to the bulk grid's own (small, ~276k-point-tuned)
+    sizes; pass POINT_SIZE_BACKGROUND/POINT_SIZE_FOREGROUND for a standalone panel sized
+    like the rest of the manuscript's scatter figures. Shared by the bulk grid and
+    single-panel manuscript extracts so both paths stay in sync.
+    Returns the colorbar mappable for color_by="gain" (None for "cell_type"), for the
+    caller to finish the figure.
+    """
+    x, y, aux = comp["get"](sd, aux_vals)
+    if color_by == "cell_type":
+        result = draw_celltype_points(ax, x, y, aux, point_size=point_size_fg)
+    else:
+        result = draw_gain_points(
+            ax, x, y, aux, point_size_bg=point_size_bg, point_size_fg=point_size_fg
+        )
+    for xv in comp["xrefs"]:
+        ax.axvline(xv, color="0.45", ls=":", lw=1.0, zorder=3)
+    for yv in comp["yrefs"]:
+        ax.axhline(yv, color="0.45", ls=":", lw=1.0, zorder=3)
+    if comp["kx_vline"] and scan["kx_upper"] is not None:
+        ax.axvline(
+            scan["kx_upper"], color="0.3", ls="--", lw=1.0, zorder=3, alpha=0.5
+        )
+    if comp["xlim"] is not None:
+        ax.set_xlim(*comp["xlim"])
+    if comp["ylim"] is not None:
+        ax.set_ylim(*comp["ylim"])
+    return result
+
+
+def plot_new_analysis(key):
+    """Render one curated single-panel analysis from NEW_ANALYSES as a standalone figure.
+
+    color_by="cell_type" panels omit their legend (see the shared fig-celltype-legend cell
+    instead); color_by="gain" panels get a colorbar, sized via FIGSIZE["square_scatter_
+    with_colorbar"] + COLORBAR_FRACTION/COLORBAR_PAD so the plot area still matches
+    FIGSIZE["square_scatter"] rather than being squeezed narrower by the colorbar.
+    """
+    spec = NEW_ANALYSES[key]
+    comp = COMPARISON_SHAPES[spec["comparison"]]
+    color_by = spec.get("color_by", "gain")
+    scan = next(s for s in SCANS if s["label"] == spec["scan_label"])
+    sd = scan_base_arrays(scan)
+
+    if color_by == "cell_type":
+        aux_vals = pair_dfs[spec["scan_label"]]["Cell_Type"].to_numpy()
+    else:
+        aux_vals = scan_colors_gain[spec["scan_label"]]
+
+    figsize = (
+        FIGSIZE["square_scatter_with_colorbar"]
+        if color_by == "gain"
+        else FIGSIZE["square_scatter"]
+    )
+    fig, ax = plt.subplots(figsize=figsize)
+    result = _draw_comparison_panel(
+        ax,
+        comp,
+        scan,
+        sd,
+        aux_vals,
+        color_by,
+        point_size_bg=POINT_SIZE_XS,
+        point_size_fg=POINT_SIZE_BACKGROUND,
+    )
+    ax.set_xlabel(comp["xlabel"])
+    ax.set_ylabel(comp["ylabel"])
+
+    if color_by == "gain":
+        fig.colorbar(
+            result,
+            ax=ax,
+            label="log2 selectivity gain, reference scan  (gray = none)",
+            fraction=COLORBAR_FRACTION,
+            pad=COLORBAR_PAD,
+        )
+    plt.tight_layout()
+    plt.show()
+```
+
+```{python}
+#| label: fig-sel-vs-kx-loose
+plot_new_analysis("sel_vs_kx_loose")
+```
+
+```{python}
+#| label: fig-sel-vs-targ1aff-loose
+plot_new_analysis("sel_vs_targ1aff_loose")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-loose
+plot_new_analysis("gain_vs_sel_loose")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-bivalent
+plot_new_analysis("gain_vs_sel_bivalent")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-mixedval
+plot_new_analysis("gain_vs_sel_mixedval")
+```
+
+```{python}
+#| label: fig-celltype-legend
+#| fig-cap: "Shared legend for the cell-type-colored NEW_ANALYSES panels above"
+# Detached legend, mirroring suppfig-scan-outliers-legend: every color_by="cell_type" panel
+# above uses the same CELL_TYPE_COLORS mapping and omits its own legend, so this one legend
+# covers all of them and can be positioned independently (e.g. in Illustrator).
+import matplotlib.lines as mlines
+
+from bicytok.figure_styles import standalone_legend_figure
+
+_celltype_legend_handles = [
+    mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
+    for ct in ALL_CELL_TYPES
+]
+standalone_legend_figure(_celltype_legend_handles, ALL_CELL_TYPES, title="Cell type")
 plt.show()
 ```
 
 ```{python}
-#| label: fig-copinning
+# ── Shared overlaid-histogram helper ──────────────────────────────────────────
+def overlay_hist(
+    ax,
+    data_by_scan,
+    bins,
+    scan_bounds=None,
+    annotate_pinned=False,
+    ref_lines=(),
+    logy=False,
+):
+    """Overlay per-scan density histograms of one output on ax.
+
+    scan_bounds: optional {scan label: bound value}, drawn as a dashed line in the
+        scan's color; with annotate_pinned, the fraction of pairs within PIN_TOL of
+        the bound is labeled.
+    ref_lines: x-values drawn as shared gray reference lines (e.g. affinity bounds).
+    logy: use a log-scaled density axis.
+    """
+    for scan in ACTIVE_SCANS:
+        ax.hist(
+            data_by_scan[scan["label"]],
+            bins=bins,
+            density=False,
+            alpha=0.55,
+            color=scan["color"],
+            label=scan["label"],
+        )
+    if logy:
+        ax.set_yscale("log")
+    for x in ref_lines:
+        ax.axvline(x, color="0.45", ls=":", lw=1.0, zorder=2)
+    if scan_bounds:
+        y_top = ax.get_ylim()[1]
+        x_lo, x_hi = bins[0], bins[-1]
+        for scan in ACTIVE_SCANS:
+            bound = scan_bounds.get(scan["label"])
+            if bound is None:
+                continue
+            ax.axvline(bound, color=scan["color"], ls="--", lw=1.5, zorder=3)
+            if annotate_pinned:
+                frac = np.mean(np.abs(data_by_scan[scan["label"]] - bound) < PIN_TOL)
+                near_right = bound > x_lo + 0.8 * (x_hi - x_lo)
+                ax.text(
+                    bound + (-0.1 if near_right else 0.1),
+                    y_top * 0.92,
+                    f"{frac:.0%} at bound",
+                    color=scan["color"],
+                    fontsize=FONT_SIZE_ANNOT,
+                    ha="right" if near_right else "left",
+                    va="top",
+                )
+
+
+def overlay_figure(
+    data_by_scan, bins, xlabel, ylabel, legend_loc, xlim=None, **hist_kwargs
+):
+    """Single-axis overlaid-histogram figure: overlay per-scan histograms, then label and show.
+
+    xlim defaults to the bin span; pass it to override (e.g. clip the selectivity axis at 1).
+    hist_kwargs pass through to overlay_hist (scan_bounds, annotate_pinned, ref_lines, logy).
+    """
+    fig, ax = plt.subplots(figsize=FIGSIZE["single_panel"])
+    overlay_hist(ax, data_by_scan, bins, **hist_kwargs)
+    ax.set_xlim(*(xlim if xlim is not None else (bins[0], bins[-1])))
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.legend(loc=legend_loc)
+    plt.tight_layout()
+    plt.show()
+
+
+# ── Precomputed distributions for the four summary figures ────────────────────
+# Concatenations below draw only from ACTIVE_SCANS labels, so bin ranges aren't stretched by
+# data (e.g. the high-valency scans) that these figures never actually plot.
+_active_labels = [s["label"] for s in ACTIVE_SCANS]
+
+kx_by_scan = {lbl: df["Kx_star"].to_numpy() for lbl, df in scan_dfs.items()}
+_all_kx = np.concatenate([kx_by_scan[lbl] for lbl in _active_labels])
+KX_BINS = np.arange(np.floor(_all_kx.min()), np.ceil(_all_kx.max()) + 0.2, 0.2)
+
+# Diagonal (rec == rec) pairs are excluded: those are modeled as a single target with
+# combined valency, so the second target receptor has valency 0 and its affinity is never
+# optimized (it stays at its initialization value).
+off_diag_dfs = {
+    lbl: df[df["Receptor_1"] != df["Receptor_2"]] for lbl, df in scan_dfs.items()
+}
+AFF_BINS = np.arange(AFFINITY_BOUNDS[0], AFFINITY_BOUNDS[1] + 0.2, 0.2)
+
+sel_by_scan = {lbl: df["Selectivity"].to_numpy() for lbl, df in scan_dfs.items()}
+_all_sel = np.concatenate([sel_by_scan[lbl] for lbl in _active_labels])
+SEL_BINS = np.linspace(_all_sel.min(), 1.0, 60)
+
+gain_by_scan = {lbl: df["log2_gain"].to_numpy() for lbl, df in pair_dfs.items()}
+_all_gain = np.concatenate([gain_by_scan[lbl] for lbl in _active_labels])
+GAIN_BINS = np.linspace(_all_gain.min(), _all_gain.max(), 70)
+
+
+def plot_kxstar_dist():
+    """Overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked.
+
+    Histograms (not KDEs) are used so the pile-up of pairs pinned at a scan's upper bound
+    is preserved rather than smeared.
+    """
+    overlay_figure(
+        kx_by_scan,
+        KX_BINS,
+        "Optimal log10(Kx*)",
+        "Number of pairs",
+        "upper left",
+        scan_bounds={scan["label"]: scan["kx_upper"] for scan in ACTIVE_SCANS},
+        annotate_pinned=True,
+    )
+
+
+def plot_affinity_dist():
+    """Overlaid affinity histograms, one subpanel per receptor (signal, target 1, target 2)."""
+    fig, axes = plt.subplots(
+        1, len(AFF_COLS), figsize=(5 * len(AFF_COLS), 4.8), sharey=True
+    )
+    for ax, (col, title) in zip(axes, AFF_COLS.items(), strict=True):
+        data = {lbl: df[col].to_numpy() for lbl, df in off_diag_dfs.items()}
+        overlay_hist(ax, data, AFF_BINS, ref_lines=AFFINITY_BOUNDS)
+        ax.set_title(title)
+        ax.set_xlim(*AFFINITY_BOUNDS)
+        ax.set_xlabel("Optimal affinity, log10(M)")
+    axes[0].set_ylabel("Number of pairs")
+    axes[0].legend(loc="upper right")
+    plt.tight_layout()
+    plt.show()
+
+
+def plot_selectivity_dist():
+    """Overlaid log-density histograms of optimal selectivity."""
+    overlay_figure(
+        sel_by_scan,
+        SEL_BINS,
+        "Optimal selectivity, targ / (targ + off-targ)",
+        "Number of pairs (log scale)",
+        "upper right",
+        xlim=(SEL_BINS[0], 1.0),
+        ref_lines=(0.5,),
+        logy=True,
+    )
+
+
+def plot_gain_dist():
+    """Overlaid log-density histogram of per-pair log2 selectivity gain (synergy)."""
+    overlay_figure(
+        gain_by_scan,
+        GAIN_BINS,
+        "log2 selectivity gain (pair / max monospecific)",
+        "Number of pairs (log scale)",
+        "upper left",
+        ref_lines=(0.0,),
+        logy=True,
+    )
+```
+
+```{python}
+#| label: fig-kxstar-dist
+plot_kxstar_dist()
+```
+
+```{python}
+#| label: fig-affinity-dist
+plot_affinity_dist()
+```
+
+```{python}
+#| label: fig-selectivity-dist
+plot_selectivity_dist()
+```
+
+```{python}
+#| label: fig-gain-dist
+plot_gain_dist()
+```
+
+```{python}
+# ── Bulk reference grid (diagnostic, not a manuscript figure) ─────────────────
+# One grid gathering every per-pair scatter from GRID_COMPARISON_KEYS: rows are comparisons,
+# columns are scans (loose bound left, tight bound right). The first four rows put each output
+# on y vs. optimal log10(Kx*) on x; the last three put log2 selectivity gain on y vs. an output
+# on x. Every panel uses the same coloring: all pairs in gray for context, with pairs that are
+# synergistic in that scan's reference scan (its "gain_ref") overlaid and colored by the
+# reference scan's log2 gain (strongest drawn last). Pointing the tight scan at the loose scan
+# maps the loose-bound gain onto the tight coordinates, so the tight-bound column shows exactly
+# where the once-synergistic pairs are trapped once Kx* is capped — pinned at the wall, driven to
+# the affinity ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales
+# are shared within a row (across scans), not down a column, so x and y labels are set per row.
+
+PANEL_W, PANEL_H = 4.3, 3.0
+
+# This grid packs 8 comparisons x len(SCANS) scans into one figure, so its labels use fixed
+# reduced sizes rather than the shared label/tick constants (which would overrun a 4.3x3.0"
+# panel repeated across many subplots); values match the original tuning for this grid.
+GRID_TITLE_FONTSIZE = 14
+GRID_LABEL_FONTSIZE = 13
+GRID_TICK_FONTSIZE = 10
+
+
+def _sync_row(axes_row):
+    """Put every panel in a comparison row on a shared x/y scale (union of the columns)."""
+    xlims = [a.get_xlim() for a in axes_row]
+    ylims = [a.get_ylim() for a in axes_row]
+    x0, x1 = min(a for a, _ in xlims), max(b for _, b in xlims)
+    y0, y1 = min(a for a, _ in ylims), max(b for _, b in ylims)
+    for a in axes_row:
+        a.set_xlim(x0, x1)
+        a.set_ylim(y0, y1)
+
+
+def build_comparison_grid():
+    """Draw the full comparison grid (rows = GRID_COMPARISON_KEYS, cols = ACTIVE_SCANS)."""
+    grid_comps = [COMPARISON_SHAPES[k] for k in GRID_COMPARISON_KEYS]
+    fig, axes = plt.subplots(
+        len(grid_comps),
+        len(ACTIVE_SCANS),
+        figsize=(PANEL_W * len(ACTIVE_SCANS), PANEL_H * len(grid_comps)),
+        squeeze=False,
+        layout="constrained",
+    )
+    mappable = None
+    for c, scan in enumerate(ACTIVE_SCANS):
+        sd = scan_base_arrays(scan)
+        for r, comp in enumerate(grid_comps):
+            ax = axes[r, c]
+            drawn = _draw_comparison_panel(
+                ax, comp, scan, sd, scan_colors_gain[scan["label"]]
+            )
+            if drawn is not None:
+                mappable = drawn
+            ax.tick_params(labelsize=GRID_TICK_FONTSIZE)
+            if r == 0:
+                ax.set_title(scan["label"], fontsize=GRID_TITLE_FONTSIZE)
+            if c == 0:
+                ax.set_ylabel(comp["ylabel"], fontsize=GRID_LABEL_FONTSIZE)
+            ax.set_xlabel(comp["xlabel"], fontsize=GRID_LABEL_FONTSIZE)
+    for row in axes:
+        _sync_row(row)
+    return fig, axes, mappable
+
+
+def plot_comparison_grid():
+    """Draw and display the full comparison grid with its shared colorbar."""
+    fig, axes, mappable = build_comparison_grid()
+    fig.colorbar(
+        mappable,
+        ax=axes.ravel().tolist(),
+        label="log2 selectivity gain, reference scan  (gray = none)",
+        fraction=0.03,
+        pad=0.02,
+    )
+    plt.show()
+```
+
+```{python}
+#| label: fig-scatter-grid
+plot_comparison_grid()
+```
+
+```{python}
 # ── Co-pinning flow: how pairs move between constraint categories ──────────────
 # Kx* and target affinity are compensatory avidity sources, so a pair that has maxed both
 # has no headroom left — it is genuinely constrained by the Kx* bound. Each pair is labeled
@@ -846,56 +1079,65 @@ def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03):
                     f"{sizes[cat] / total * 100:.0f}%",
                     ha=ha,
                     va="center",
-                    fontsize=FS_ANNOT,
+                    fontsize=FONT_SIZE_ANNOT,
                 )
     ax.set_xlim(-0.22, 1.22)
     ax.set_ylim(-0.02, 1.09)
     ax.axis("off")
 
 
-# Flow from the first (loosest) to the second (tightest) scan.
-scan_a, scan_b = SCANS[0], SCANS[1]
-cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
-cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
-matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
-cats = range(len(CAT_NAMES))
-trans = (
-    pd.crosstab(matched["cat_a"], matched["cat_b"])
-    .reindex(index=cats, columns=cats, fill_value=0)
-    .to_numpy()
-)
+def build_copinning_flow(scan_a, scan_b):
+    """Compute the co-pinning category transition matrix between two scans."""
+    cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
+    cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
+    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+    cats = range(len(CAT_NAMES))
+    return (
+        pd.crosstab(matched["cat_a"], matched["cat_b"])
+        .reindex(index=cats, columns=cats, fill_value=0)
+        .to_numpy()
+    )
 
-fig, ax = plt.subplots(figsize=(9, 7))
-draw_category_flow(ax, trans, CAT_COLORS)
-ax.text(
-    0,
-    1.07,
-    scan_a["label"],
-    ha="center",
-    va="bottom",
-    fontsize=FS_LABEL,
-    fontweight="bold",
-)
-ax.text(
-    1,
-    1.07,
-    scan_b["label"],
-    ha="center",
-    va="bottom",
-    fontsize=FS_LABEL,
-    fontweight="bold",
-)
-ax.legend(
-    handles=[
-        Patch(facecolor=CAT_COLORS[i], label=CAT_NAMES[i])
-        for i in range(len(CAT_NAMES))
-    ],
-    loc="lower center",
-    bbox_to_anchor=(0.5, -0.06),
-    ncol=len(CAT_NAMES),
-    fontsize=FS_LEGEND,
-    frameon=False,
-)
-plt.tight_layout()
-plt.show()
+
+def plot_copinning(scan_a, scan_b):
+    """Draw the co-pinning alluvial flow from scan_a to scan_b as a standalone figure."""
+    trans = build_copinning_flow(scan_a, scan_b)
+    fig, ax = plt.subplots(figsize=(9, 7))
+    draw_category_flow(ax, trans, CAT_COLORS)
+    ax.text(
+        0,
+        1.07,
+        scan_a["label"],
+        ha="center",
+        va="bottom",
+        fontsize=FONT_SIZE_TITLE,
+        fontweight="bold",
+    )
+    ax.text(
+        1,
+        1.07,
+        scan_b["label"],
+        ha="center",
+        va="bottom",
+        fontsize=FONT_SIZE_TITLE,
+        fontweight="bold",
+    )
+    ax.legend(
+        handles=[
+            Patch(facecolor=CAT_COLORS[i], label=CAT_NAMES[i])
+            for i in range(len(CAT_NAMES))
+        ],
+        loc="lower center",
+        bbox_to_anchor=(0.5, -0.06),
+        ncol=len(CAT_NAMES),
+        frameon=False,
+    )
+    plt.tight_layout()
+    plt.show()
+```
+
+```{python}
+#| label: fig-copinning
+# Flow from the first (loosest) to the second (tightest) active scan.
+plot_copinning(ACTIVE_SCANS[0], ACTIVE_SCANS[1])
 ```

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -47,19 +47,16 @@ import numpy as np
 import pandas as pd
 import yaml
 from matplotlib.colors import Normalize
-from matplotlib.patches import Patch
 
 from bicytok.figure_styles import (
-    CMAPS,
+    CELL_TYPE_COLORS,
+    CELL_TYPES,
     COLORBAR_FRACTION,
     COLORBAR_PAD,
     FIGSIZE,
-    FONT_SIZE_ANNOT,
-    FONT_SIZE_TITLE,
-    POINT_SIZE_XS,
     POINT_SIZE_BACKGROUND,
+    POINT_SIZE_XS,
     apply_style,
-    categorical_colors,
 )
 
 apply_style()
@@ -513,20 +510,14 @@ for scan in SCANS:
 
 gain_norm = Normalize(vmin=0, vmax=GAIN_COLOR_MAX)
 
-# Canonical cell-type -> color mapping, shared by every color_by="cell_type" NEW_ANALYSES
-# panel and the standalone fig-celltype-legend cell below, so a given cell type always gets
-# the same color regardless of which scan's panel it appears in (a per-panel local mapping
-# would assign colors by sorted position, which can point to different cell types across
-# panels whose present-cell-type sets differ slightly).
+# Cell types actually present across this file's loaded scans, in the project-wide
+# canonical order (see bicytok.figure_styles.CELL_TYPES): every color_by="cell_type"
+# NEW_ANALYSES panel and the standalone fig-celltype-legend cell below look colors up in
+# the shared CELL_TYPE_COLORS, so a given cell type gets the same color here as it does in
+# scan_comparison_scatter.qmd and any other all-cell-type analysis, not just within this file.
 ALL_CELL_TYPES = sorted(
-    set().union(*(df["Cell_Type"].unique() for df in pair_dfs.values()))
-)
-CELL_TYPE_COLORS = dict(
-    zip(
-        ALL_CELL_TYPES,
-        categorical_colors(len(ALL_CELL_TYPES), cmap_name=CMAPS["categorical_large"]),
-        strict=True,
-    )
+    set().union(*(df["Cell_Type"].unique() for df in pair_dfs.values())),
+    key=CELL_TYPES.index,
 )
 
 
@@ -720,6 +711,9 @@ plt.show()
 
 ```{python}
 # ── Shared overlaid-histogram helper ──────────────────────────────────────────
+from bicytok.figure_styles import FONT_SIZE_ANNOT
+
+
 def overlay_hist(
     ax,
     data_by_scan,
@@ -990,7 +984,9 @@ plot_comparison_grid()
 # under the tight bound. Ribbons are colored by source category, so each destination block's
 # composition reveals where its pairs were pulled from.
 
-from matplotlib.patches import Rectangle
+from matplotlib.patches import Patch, Rectangle
+
+from bicytok.figure_styles import FONT_SIZE_TITLE
 
 CAT_NAMES = ["Both interior", "Aff ceiling only", "Kx* pinned only", "Doubly pinned"]
 CAT_COLORS = ["#B4B4B4", "#E8A33D", "#4DAF9A", "#C0392B"]

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -217,16 +217,19 @@ NEW_ANALYSES = {
         comparison="gain_vs_sel",
         scan_label="Kx* upper bound 1e-5",
         color_by="gain",
+        log_y=True,
     ),
     "gain_vs_sel_bivalent": dict(
         comparison="gain_vs_sel",
         scan_label="Bivalent Kx* upper bound 1e-5",
         color_by="gain",
+        log_y=True,
     ),
     "gain_vs_sel_mixedval": dict(
         comparison="gain_vs_sel",
         scan_label="Mixed Valency Kx* upper bound 1e-5",
         color_by="gain",
+        log_y=True,
     ),
 }
 
@@ -311,9 +314,9 @@ def pair_key(df):
 # ── Comparison shapes: x/y axes, reference lines, limits ──────────────────────
 SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
 GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
-KX_XLABEL = "Optimal log10(Kx*)"
-GAIN_YLABEL = "log2 selectivity gain"
-SELECTIVITY_XLABEL = "Pair selectivity"
+KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
+GAIN_YLABEL = r"log$_{2}$ selectivity gain"
+SELECTIVITY_XLABEL = "Binding model selectivity"
 
 # ~276k points per panel in the bulk grid: far denser than the shared point-size constants
 # assume (tuned for scatter plots with far fewer points), so these panels keep their own
@@ -382,25 +385,25 @@ def _row(get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vl
 
 
 COMPARISON_SHAPES = {
-    "sel_vs_kx": _row(_vs_kxstar("sel"), KX_XLABEL, "Selectivity", yrefs=(0.5,), kx_vline=True),
+    "sel_vs_kx": _row(_vs_kxstar("sel"), KX_XLABEL, SELECTIVITY_XLABEL, yrefs=(0.5,), kx_vline=True),
     "sig_aff_vs_kx": _row(
         _vs_kxstar("aff0"),
         KX_XLABEL,
-        "Signal aff, log10(M)",
+        r"Signal receptor K$_{a}$ (log$_{10}$(M))",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
     "targ1_aff_vs_kx": _row(
         _vs_kxstar("aff1"),
         KX_XLABEL,
-        "Target 1 aff, log10(M)",
+        r"Target receptor 1 K$_{a}$ (log$_{10}$(M))",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
     "targ2_aff_vs_kx": _row(
         _vs_kxstar("aff2"),
         KX_XLABEL,
-        "Target 2 aff, log10(M)",
+        r"Target receptor 2 K$_{a}$ (log$_{10}$(M))",
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
@@ -414,7 +417,7 @@ COMPARISON_SHAPES = {
     "sig_aff_vs_sel": _row(
         _vs_selectivity("aff0"),
         SELECTIVITY_XLABEL,
-        "Signal aff, log10(M)",
+        r"Signal receptor K$_{a}$ (log$_{10}$(M))",
         xrefs=(SELEC_FLOOR,),
         xlim=SELEC_BOUNDS,
         ylim=AFFINITY_BOUNDS,
@@ -423,7 +426,7 @@ COMPARISON_SHAPES = {
     "targ1_aff_vs_sel": _row(
         _vs_selectivity("aff1"),
         SELECTIVITY_XLABEL,
-        "Target 1 aff, log10(M)",
+        r"Target receptor 1 K$_{a}$ (log$_{10}$(M))",
         xrefs=(SELEC_FLOOR,),
         xlim=SELEC_BOUNDS,
         ylim=AFFINITY_BOUNDS,
@@ -432,7 +435,7 @@ COMPARISON_SHAPES = {
     "targ2_aff_vs_sel": _row(
         _vs_selectivity("aff2"),
         SELECTIVITY_XLABEL,
-        "Target 2 aff, log10(M)",
+        r"Target receptor 2 K$_{a}$ (log$_{10}$(M))",
         xrefs=(SELEC_FLOOR,),
         xlim=SELEC_BOUNDS,
         ylim=AFFINITY_BOUNDS,
@@ -445,15 +448,15 @@ COMPARISON_SHAPES = {
     "sel_vs_kx_loose": _row(
         _vs_kxstar("sel"),
         KX_XLABEL,
-        "Selectivity",
+        SELECTIVITY_XLABEL,
         ylim=SELEC_BOUNDS,
         yrefs=(0.5,),
         kx_vline=True,
     ),
     "sel_vs_targ1_aff": _row(
         _sel_vs("aff1"),
-        "Target 1 aff, log10(M)",
-        "Selectivity",
+        r"Target receptor K$_{a}$ (log$_{10}$(M))",
+        SELECTIVITY_XLABEL,
         xlim=AFFINITY_BOUNDS,
         ylim=SELEC_BOUNDS,
         yrefs=(0.5,),
@@ -657,11 +660,14 @@ def plot_new_analysis(key):
     ax.set_xlabel(comp["xlabel"])
     ax.set_ylabel(comp["ylabel"])
 
+    if spec.get("log_y"):
+        ax.set_yscale("log")
+
     if color_by == "gain":
         fig.colorbar(
             result,
             ax=ax,
-            label="log2 selectivity gain, reference scan  (gray = none)",
+            label=r"log$_{2}$ selectivity gain",
             fraction=COLORBAR_FRACTION,
             pad=COLORBAR_PAD,
         )

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -214,6 +214,12 @@ NEW_ANALYSES = {
         comparison="gain_vs_sel",
         scan_label="Kx* upper bound 1e-5",
         color_by="gain",
+        log_y=False,
+    ),
+    "gain_vs_sel_loose_log": dict(
+        comparison="gain_vs_sel",
+        scan_label="Kx* upper bound 1e-5",
+        color_by="gain",
         log_y=True,
     ),
     "gain_vs_sel_bivalent": dict(
@@ -311,6 +317,7 @@ def pair_key(df):
 # ── Comparison shapes: x/y axes, reference lines, limits ──────────────────────
 SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
 GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
+LOG_Y_GAIN_FLOOR = 1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
 KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
 GAIN_YLABEL = r"log$_{2}$ selectivity gain"
 SELECTIVITY_XLABEL = "Binding model selectivity"
@@ -653,6 +660,7 @@ def plot_new_analysis(key):
 
     if spec.get("log_y"):
         ax.set_yscale("log")
+        ax.set_ylim(bottom=LOG_Y_GAIN_FLOOR)
 
     if color_by == "gain":
         fig.colorbar(
@@ -679,6 +687,11 @@ plot_new_analysis("sel_vs_targ1aff_loose")
 ```{python}
 #| label: fig-gain-vs-sel-loose
 plot_new_analysis("gain_vs_sel_loose")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-loose-log
+plot_new_analysis("gain_vs_sel_loose_log")
 ```
 
 ```{python}

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -1,0 +1,901 @@
+---
+title: "Kx* Upper-Bound Effect on Selectivity Scans"
+---
+
+# Summary
+Investigates why selectivity scans yield markedly different synergy depending on the upper bound imposed on Kx* during affinity optimization (see `scan_synergy.qmd`). A scan with an upper bound of 1e-5 gives widespread synergy, while an otherwise-identical scan with an upper bound of 1e-9 exhibits limited, low-gain synergy.
+
+This figure compares the distributions of all binding-model outputs across two (or more) selectivity scans. Each optimization returns, per receptor pair per cell type, a single log10(Kx*), one monomer affinity per receptor (signal + two targets), and a selectivity value. Four panels aggregate those outputs (and a derived synergy gain) over all successfully optimized pairs:
+
+1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked. When a large fraction of pairs optimize to Kx* above the tighter bound, that bound pins them at the wall, compressing the high-Kx* population and plausibly suppressing synergy.
+2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs are excluded here because the second target receptor is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
+3. **Selectivity distribution** — optimal selectivity, targ / (targ + off-targ), on a log density axis to reveal the high-selectivity tail above the ~0.5 no-selectivity floor.
+4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy (the pair beats either receptor alone). The signal receptor is excluded here, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
+
+A consolidated scatter grid (`fig-scatter-grid`) gathers every per-pair scatter into one figure: rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. This one figure therefore answers whether the high-Kx* pairs are the selective, synergistic ones; whether that population is dominated by degenerate near-floor pairs; how affinity compensates for capped Kx*; and where the constrained pairs end up. Points are rasterized (~276k per panel).
+
+`fig-scatter-grid-celltype` repeats the same grid with points colored by cell type instead of gain, exposing which cell types occupy which regions of these spaces.
+
+A co-pinning flow panel (`fig-copinning`) labels each pair by whether it is pinned at its Kx* upper bound and whether a target arm sits at the affinity ceiling (four categories: both interior, aff ceiling only, Kx* pinned only, doubly pinned). Pairs are matched across scans and an alluvial diagram shows how the loose-bound categories redistribute under the tight bound — revealing which pool each constrained category is pulled from.
+
+# Inputs
+- `SCANS`: list of selectivity scans to compare, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory.
+- `AFFINITY_BOUNDS`: shared (min, max) affinity optimization bounds in log10(M), drawn as reference lines in the affinity panel.
+
+# Outputs
+- **`fig-kxstar-dist`**: overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked and the fraction of pairs pinned at that bound annotated
+- **`fig-affinity-dist`**: overlaid density histograms of optimal affinity, one subpanel per receptor (signal, target 1, target 2); diagonal pairs excluded
+- **`fig-selectivity-dist`**: overlaid log-density histograms of optimal selectivity
+- **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain (bispecific / max constituent monospecific); gain > 1 is synergy
+- **`fig-scatter-grid`**: rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
+- **`fig-scatter-grid-celltype`**: the same grid colored by cell type, showing where cell types sit in these spaces
+- **`fig-copinning`**: cross-scan alluvial flow of pairs between four constraint categories (Kx*-pinned × target-affinity-ceiling), showing where each tight-bound category is pulled from
+
+```{python}
+%config InlineBackend.figure_formats = ['svg']
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import yaml
+
+# ── Parameters ────────────────────────────────────────────────────────────────
+# Each scan's "gain_ref" names the scan (by label) whose per-pair gain colors this scan's points
+# in fig-scatter-grid: its own label uses its own gain; another scan's label maps that scan's gain
+# onto these coordinates (pointing the tight scan at the loose scan reveals where pairs get
+# trapped once Kx* is capped).
+SCANS = [
+    # Loose Kx* bound scan
+    {
+        "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv",
+        "label": "Kx* upper bound 1e-5",
+        "kx_upper": -5.0,
+        "color": "#2774AE",
+        "gain_ref": "Kx* upper bound 1e-5",
+    },
+
+    # Tight Kx* bound scan
+    {
+        "path": "/home/sama/receptor_sweep_data/20260720_selec_scan_rand42.csv",
+        "label": "Kx* upper bound 1e-9",
+        "kx_upper": -9.0,
+        "color": "#CF4D6F",
+        "gain_ref": "Kx* upper bound 1e-5",
+    },
+
+    # High-valency scans
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260529_selec_scan_full_bival.csv",
+    #     "label": "Bivalent Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#4E9A06",
+    #     "gain_ref": "Bivalent Kx* upper bound 1e-5",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260608_selec_scan_full_mix-val.csv",
+    #     "label": "Mixed Valency Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#FF7F00",
+    #     "gain_ref": "Mixed ValencyKx* upper bound 1e-5",
+    # },
+
+    # # Specified signal receptor scan
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260604_selec_scan_full_sigCD122.csv",
+    #     "label": "Signal CD122 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#A020F0",
+    #     "gain_ref": "Signal CD122 Kx* upper bound 1e-5",
+    # },
+
+    # # Count normalization scans
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/old_scan_results/old_tight_kx_bound/20260714_selec_scan_full_norm.csv",
+    #     "label": "Normalized Kx* upper bound 1e-9",
+    #     "kx_upper": -9.0,
+    #     "color": "#4B0082",
+    #     "gain_ref": "Normalized Kx* upper bound 1e-9",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260723_selec_scan_full_norm_filt_kxup.csv",
+    #     "label": "Normalized 1000 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#FF7F00",
+    #     "gain_ref": "Normalized 1000 Kx* upper bound 1e-5",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260804_selec_scan_full_norm_filt_100.csv",
+    #     "label": "Normalized 100 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#4E9A06",
+    #     "gain_ref": "Normalized 100 Kx* upper bound 1e-5",
+    # },
+
+    # # Variable filter-strength scans
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt3.csv",
+    #     "label": "Filtered 3.0 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#4B0082",
+    #     "gain_ref": "Filtered 3.0 Kx* upper bound 1e-5",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt2.csv",
+    #     "label": "Filtered 2.0 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#FF7F00",
+    #     "gain_ref": "Filtered 2.0 Kx* upper bound 1e-5",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt1-5.csv",
+    #     "label": "Filtered 1.5 Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#4E9A06",
+    #     "gain_ref": "Filtered 1.5 Kx* upper bound 1e-5",
+    # },
+    # {
+    #     "path": "/home/sama/receptor_sweep_data/old_scan_results/20260520_selec_scan_full_filt.csv",
+    #     "label": "Filtered Kx* upper bound 1e-5",
+    #     "kx_upper": -5.0,
+    #     "color": "#CF4D6F",
+    #     "gain_ref": "Filtered Kx* upper bound 1e-5",
+    # },
+]
+
+# True affinity optimization bounds, log10(M), used for pin/ceiling logic. AFFINITY_BOUNDS pads
+# these for display so points and bars sitting exactly at a bound are not clipped at the spine.
+AFFINITY_OPT_BOUNDS = (6.0, 12.0)
+AFFINITY_BOUNDS = (5.9, 12.1)
+
+# Affinity CSV columns mapped to their receptor role (order = subpanel order).
+AFF_COLS = {
+    "Affinity_Receptor_0": "Signal receptor",
+    "Affinity_Receptor_1": "Target receptor 1",
+    "Affinity_Receptor_2": "Target receptor 2",
+}
+
+# Signal (readout) receptor name, excluded from the pair-level gain metric because a pair
+# containing the artificial signal receptor is not a genuine two-target combination.
+SIGNAL_REC_NAME = "Prototype_Signal_Receptor"
+
+# ── Font size constants (shared across panels) ────────────────────────────────
+FS_LABEL = 14
+FS_TICK = 12
+FS_LEGEND = 11
+FS_ANNOT = 10
+
+# Fraction pinned is counted within this log10 tolerance of the bound; a target affinity within
+# AFF_CEIL_EPS of the optimization ceiling counts as sitting "at the ceiling".
+PIN_TOL = 1e-2
+AFF_CEIL_EPS = 1e-2
+
+
+# ── Load binding-model outputs from each scan ─────────────────────────────────
+def load_scan_outputs(scan):
+    """Return a DataFrame of successfully optimized pairs for one selectivity scan.
+
+    Rows with NaN outputs (uncomputed upper triangle, failed optimizations) are
+    dropped; these are NaN across all output columns simultaneously.
+    """
+    yaml_path = os.path.splitext(scan["path"])[0] + ".yaml"
+    assert os.path.exists(yaml_path), f"YAML not found at {yaml_path}"
+    with open(yaml_path) as f:
+        assert yaml.safe_load(f)["scan_type"] == "selectivity", (
+            f"{scan['path']} is not a selectivity scan; Kx* and affinities are only "
+            "optimized there."
+        )
+
+    cols = [
+        "Cell_Type",
+        "Receptor_1",
+        "Receptor_2",
+        "Selectivity",
+        "Kx_star",
+        *AFF_COLS,
+    ]
+    return pd.read_csv(scan["path"], usecols=cols).dropna(subset=["Selectivity"])
+
+
+scan_dfs = {scan["label"]: load_scan_outputs(scan) for scan in SCANS}
+
+
+# ── Per-pair selectivity gain (synergy) ───────────────────────────────────────
+def compute_pair_gains(df):
+    """Return off-diagonal pairs with an added synergy gain column.
+
+    gain = bispecific selectivity / max(constituent monospecific selectivities), where the
+    monospecific values are the diagonal (rec == rec) entries. The artificial signal
+    receptor is excluded from pair membership. Rows retain all binding-model outputs so the
+    returned table also serves the per-pair metric comparisons downstream.
+
+    Diagonal (mono) entries model a single receptor carrying the combined target valency,
+    while off-diagonal pairs split that valency one arm per receptor, so the comparison
+    holds total target valency fixed. gain < 1 (the common case) means concentrating
+    valency on the better single receptor beats splitting it across two.
+    """
+    mono_map = df[df["Receptor_1"] == df["Receptor_2"]].set_index(
+        ["Cell_Type", "Receptor_1"]
+    )["Selectivity"]
+    assert mono_map.index.is_unique, (
+        "Duplicate monospecific (cell type, receptor) entries."
+    )
+
+    pairs = df[
+        (df["Receptor_1"] != df["Receptor_2"])
+        & (df["Receptor_1"] != SIGNAL_REC_NAME)
+        & (df["Receptor_2"] != SIGNAL_REC_NAME)
+    ].copy()
+    mono1 = mono_map.reindex(
+        list(zip(pairs["Cell_Type"], pairs["Receptor_1"], strict=True))
+    ).to_numpy()
+    mono2 = mono_map.reindex(
+        list(zip(pairs["Cell_Type"], pairs["Receptor_2"], strict=True))
+    ).to_numpy()
+    pairs["max_mono_selec"] = np.maximum(mono1, mono2)
+    pairs["gain"] = pairs["Selectivity"] / pairs["max_mono_selec"]
+    pairs["log2_gain"] = np.log2(pairs["gain"])
+    return pairs.dropna(subset=["gain"])
+
+
+pair_dfs = {lbl: compute_pair_gains(df) for lbl, df in scan_dfs.items()}
+
+
+# ── Cross-scan pair identifier ────────────────────────────────────────────────
+def pair_key(df):
+    """Stable per-pair key (cell type + sorted receptor pair) for matching across scans."""
+    recs = np.sort(df[["Receptor_1", "Receptor_2"]].to_numpy(), axis=1)
+    return df["Cell_Type"].to_numpy() + "|" + recs[:, 0] + "|" + recs[:, 1]
+
+
+# ── Shared overlaid-histogram helper ──────────────────────────────────────────
+def overlay_hist(
+    ax,
+    data_by_scan,
+    bins,
+    scan_bounds=None,
+    annotate_pinned=False,
+    ref_lines=(),
+    logy=False,
+):
+    """Overlay per-scan density histograms of one output on ax.
+
+    scan_bounds: optional {scan label: bound value}, drawn as a dashed line in the
+        scan's color; with annotate_pinned, the fraction of pairs within PIN_TOL of
+        the bound is labeled.
+    ref_lines: x-values drawn as shared gray reference lines (e.g. affinity bounds).
+    logy: use a log-scaled density axis.
+    """
+    for scan in SCANS:
+        ax.hist(
+            data_by_scan[scan["label"]],
+            bins=bins,
+            density=False,
+            alpha=0.55,
+            color=scan["color"],
+            label=scan["label"],
+        )
+    if logy:
+        ax.set_yscale("log")
+    for x in ref_lines:
+        ax.axvline(x, color="0.45", ls=":", lw=1.0, zorder=2)
+    if scan_bounds:
+        y_top = ax.get_ylim()[1]
+        x_lo, x_hi = bins[0], bins[-1]
+        for scan in SCANS:
+            bound = scan_bounds.get(scan["label"])
+            if bound is None:
+                continue
+            ax.axvline(bound, color=scan["color"], ls="--", lw=1.5, zorder=3)
+            if annotate_pinned:
+                frac = np.mean(np.abs(data_by_scan[scan["label"]] - bound) < PIN_TOL)
+                near_right = bound > x_lo + 0.8 * (x_hi - x_lo)
+                ax.text(
+                    bound + (-0.1 if near_right else 0.1),
+                    y_top * 0.92,
+                    f"{frac:.0%} at bound",
+                    color=scan["color"],
+                    fontsize=FS_ANNOT,
+                    ha="right" if near_right else "left",
+                    va="top",
+                )
+    ax.tick_params(labelsize=FS_TICK)
+
+
+def overlay_figure(
+    data_by_scan, bins, xlabel, ylabel, legend_loc, xlim=None, **hist_kwargs
+):
+    """Single-axis overlaid-histogram figure: overlay per-scan histograms, then label and show.
+
+    xlim defaults to the bin span; pass it to override (e.g. clip the selectivity axis at 1).
+    hist_kwargs pass through to overlay_hist (scan_bounds, annotate_pinned, ref_lines, logy).
+    """
+    fig, ax = plt.subplots(figsize=(8, 5.5))
+    overlay_hist(ax, data_by_scan, bins, **hist_kwargs)
+    ax.set_xlim(*(xlim if xlim is not None else (bins[0], bins[-1])))
+    ax.set_xlabel(xlabel, fontsize=FS_LABEL)
+    ax.set_ylabel(ylabel, fontsize=FS_LABEL)
+    ax.legend(fontsize=FS_LEGEND, loc=legend_loc)
+    plt.tight_layout()
+    plt.show()
+```
+
+```{python}
+#| label: fig-kxstar-dist
+# ── Distribution of optimal Kx* across scans ──────────────────────────────────
+# Overlaid density histograms of optimal log10(Kx*). Histograms (not KDEs) are used so
+# the pile-up of pairs pinned at a scan's upper bound is preserved rather than smeared.
+# When a scan's bound sits below where many pairs would otherwise optimize, those pairs
+# stack against the wall, forming a spike at the bound.
+
+kx_by_scan = {lbl: df["Kx_star"].to_numpy() for lbl, df in scan_dfs.items()}
+
+all_kx = np.concatenate(list(kx_by_scan.values()))
+bins = np.arange(np.floor(all_kx.min()), np.ceil(all_kx.max()) + 0.2, 0.2)
+
+overlay_figure(
+    kx_by_scan,
+    bins,
+    "Optimal log10(Kx*)",
+    "Number of pairs",
+    "upper left",
+    scan_bounds={scan["label"]: scan["kx_upper"] for scan in SCANS},
+    annotate_pinned=True,
+)
+```
+
+```{python}
+#| label: fig-affinity-dist
+# ── Distributions of optimal affinities per receptor ──────────────────────────
+# One subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs
+# are excluded: those are modeled as a single target with combined valency, so the
+# second target receptor has valency 0 and its affinity is never optimized (it stays at
+# its initialization value). Reference lines mark the shared affinity bounds.
+
+off_diag_dfs = {
+    lbl: df[df["Receptor_1"] != df["Receptor_2"]] for lbl, df in scan_dfs.items()
+}
+aff_bins = np.arange(AFFINITY_BOUNDS[0], AFFINITY_BOUNDS[1] + 0.2, 0.2)
+
+fig, axes = plt.subplots(
+    1, len(AFF_COLS), figsize=(5 * len(AFF_COLS), 4.8), sharey=True
+)
+for ax, (col, title) in zip(axes, AFF_COLS.items(), strict=True):
+    data = {lbl: df[col].to_numpy() for lbl, df in off_diag_dfs.items()}
+    overlay_hist(ax, data, aff_bins, ref_lines=AFFINITY_BOUNDS)
+    ax.set_title(title, fontsize=FS_LABEL)
+    ax.set_xlim(*AFFINITY_BOUNDS)
+    ax.set_xlabel("Optimal affinity, log10(M)", fontsize=FS_LABEL)
+axes[0].set_ylabel("Number of pairs", fontsize=FS_LABEL)
+axes[0].legend(fontsize=FS_LEGEND, loc="upper right")
+plt.tight_layout()
+plt.show()
+```
+
+```{python}
+#| label: fig-selectivity-dist
+# ── Distribution of optimal selectivity across scans ──────────────────────────
+# Selectivity = targ / (targ + off-targ), bounded in (0, 1], structurally floored near
+# 0.5 (equal on/off-target binding, i.e. no selectivity). A log density axis reveals the
+# high-selectivity tail; a reference line marks the 0.5 floor.
+
+sel_by_scan = {lbl: df["Selectivity"].to_numpy() for lbl, df in scan_dfs.items()}
+
+all_sel = np.concatenate(list(sel_by_scan.values()))
+sel_bins = np.linspace(all_sel.min(), 1.0, 60)
+
+overlay_figure(
+    sel_by_scan,
+    sel_bins,
+    "Optimal selectivity, targ / (targ + off-targ)",
+    "Number of pairs (log scale)",
+    "upper right",
+    xlim=(sel_bins[0], 1.0),
+    ref_lines=(0.5,),
+    logy=True,
+)
+```
+
+```{python}
+#| label: fig-gain-dist
+# ── Distribution of per-pair selectivity gain (synergy) ───────────────────────
+# log2(gain) per pair, gain = bispecific / max(constituent monospecific). A log density
+# axis is essential: the bulk of pairs sit at gain ~= 1 (the optimizer falls back to the
+# better single receptor), so the scans differ only in the tails. The right tail (gain > 1)
+# is genuine synergy; the reference line at 0 marks gain = 1 (no synergy).
+
+gain_by_scan = {lbl: df["log2_gain"].to_numpy() for lbl, df in pair_dfs.items()}
+
+all_gain = np.concatenate(list(gain_by_scan.values()))
+gain_bins = np.linspace(all_gain.min(), all_gain.max(), 70)
+
+overlay_figure(
+    gain_by_scan,
+    gain_bins,
+    "log2 selectivity gain (pair / max monospecific)",
+    "Number of pairs (log scale)",
+    "upper left",
+    ref_lines=(0.0,),
+    logy=True,
+)
+```
+
+```{python}
+#| label: fig-scatter-grid
+# ── Consolidated scatter comparisons, colored by loose-bound synergy ──────────
+# One grid gathering every per-pair scatter: rows are comparisons, columns are scans (loose
+# bound left, tight bound right). The first four rows put each output on y vs. optimal
+# log10(Kx*) on x; the last three put log2 selectivity gain on y vs. an output on x. Every
+# panel uses the same coloring: all pairs in gray for context, with pairs that are synergistic
+# in that scan's reference scan (its "gain_ref") overlaid and colored by the reference scan's
+# log2 gain (strongest drawn last). Pointing the tight scan at the loose scan maps the loose-bound
+# gain onto the tight coordinates, so the tight-bound column shows exactly where the once-
+# synergistic pairs are trapped once Kx* is capped — pinned at the wall, driven to the affinity
+# ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales are shared
+# within a row (across scans), not down a column, so x and y labels are set per row.
+
+from matplotlib.colors import Normalize
+
+SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
+SELEC_BOUNDS = (0.47, 1.02)
+GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
+KX_XLABEL = "Optimal log10(Kx*)"
+GAIN_YLABEL = "log2 selectivity gain"
+SELECTIVITY_XLABEL = "Pair selectivity"
+PANEL_W, PANEL_H = 4.3, 3.0
+
+
+def _vs_kxstar(ykey):
+    """Comparison getter: an output on y against optimal log10(Kx*) on x."""
+
+    def get(sd, cvals):
+        return sd["kx"], sd[ykey], cvals
+
+    return get
+
+
+def _gain_vs(xkey):
+    """Comparison getter: log2 gain on y against an output on x.
+
+    The pooled target-affinity comparison stacks both target arms, tiling y and the color
+    values to match the doubled x.
+    """
+
+    def get(sd, cvals):
+        if xkey == "targ_aff":
+            x = np.concatenate([sd["aff1"], sd["aff2"]])
+            return x, np.tile(sd["log2_gain"], 2), np.concatenate([cvals, cvals])
+        return sd[xkey], sd["log2_gain"], cvals
+
+    return get
+
+def _vs_selectivity(ykey):
+    """Comparison getter: an output on y against selectivity on x."""
+
+    def get(sd, cvals):
+        return sd["sel"], sd[ykey], cvals
+
+    return get
+
+
+# One row per comparison. xrefs/yrefs are gray reference lines; kx_vline draws each scan's Kx*
+# upper bound; ylim fixes the display range (affinity panels use padded bounds). _row supplies the
+# shared defaults so each entry states only what differs.
+def _row(get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vline=False):
+    return dict(
+        get=get,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        xlim=xlim,
+        ylim=ylim,
+        xrefs=xrefs,
+        yrefs=yrefs,
+        kx_vline=kx_vline,
+    )
+
+
+COMPARISONS = [
+    _row(_vs_kxstar("sel"), KX_XLABEL, "Selectivity", yrefs=(0.5,), kx_vline=True),
+    _row(
+        _vs_kxstar("aff0"),
+        KX_XLABEL,
+        "Signal aff, log10(M)",
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+    _row(
+        _vs_kxstar("aff1"),
+        KX_XLABEL,
+        "Target 1 aff, log10(M)",
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+    _row(
+        _vs_kxstar("aff2"),
+        KX_XLABEL,
+        "Target 2 aff, log10(M)",
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+    _row(
+        _gain_vs("sel"),
+        SELECTIVITY_XLABEL,
+        GAIN_YLABEL,
+        xrefs=(SELEC_FLOOR,),
+        yrefs=(0.0,),
+    ),
+    _row(
+        _vs_selectivity("aff0"),
+        SELECTIVITY_XLABEL,
+        "Signal aff, log10(M)",
+        xrefs=(SELEC_FLOOR,),
+        xlim=SELEC_BOUNDS,
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+    _row(
+        _vs_selectivity("aff1"),
+        SELECTIVITY_XLABEL,
+        "Target 1 aff, log10(M)",
+        xrefs=(SELEC_FLOOR,),
+        xlim=SELEC_BOUNDS,
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+    _row(
+        _vs_selectivity("aff2"),
+        SELECTIVITY_XLABEL,
+        "Target 2 aff, log10(M)",
+        xrefs=(SELEC_FLOOR,),
+        xlim=SELEC_BOUNDS,
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    ),
+
+]
+
+
+def scan_base_arrays(scan):
+    """Per-pair binding-model outputs for one scan, as plain arrays keyed by short name."""
+    df = pair_dfs[scan["label"]]
+    return {
+        "kx": df["Kx_star"].to_numpy(),
+        "sel": df["Selectivity"].to_numpy(),
+        "aff0": df["Affinity_Receptor_0"].to_numpy(),
+        "aff1": df["Affinity_Receptor_1"].to_numpy(),
+        "aff2": df["Affinity_Receptor_2"].to_numpy(),
+        "log2_gain": df["log2_gain"].to_numpy(),
+    }
+
+
+def _sync_row(axes_row):
+    """Put every panel in a comparison row on a shared x/y scale (union of the columns)."""
+    xlims = [a.get_xlim() for a in axes_row]
+    ylims = [a.get_ylim() for a in axes_row]
+    x0, x1 = min(a for a, _ in xlims), max(b for _, b in xlims)
+    y0, y1 = min(a for a, _ in ylims), max(b for _, b in ylims)
+    for a in axes_row:
+        a.set_xlim(x0, x1)
+        a.set_ylim(y0, y1)
+
+
+def build_comparison_grid(scan_colors, draw_points):
+    """Draw the comparison grid (rows = comparisons, cols = scans).
+
+    scan_colors: {scan label: per-point color value aligned to pair_dfs[label]}.
+    draw_points: fn(ax, x, y, color_values) -> optional mappable (captured for a colorbar).
+    """
+    fig, axes = plt.subplots(
+        len(COMPARISONS),
+        len(SCANS),
+        figsize=(PANEL_W * len(SCANS), PANEL_H * len(COMPARISONS)),
+        squeeze=False,
+        layout="constrained",
+    )
+    mappable = None
+    for c, scan in enumerate(SCANS):
+        sd = scan_base_arrays(scan)
+        cbase = scan_colors[scan["label"]]
+        for r, comp in enumerate(COMPARISONS):
+            ax = axes[r, c]
+            x, y, cvals = comp["get"](sd, cbase)
+            drawn = draw_points(ax, x, y, cvals)
+            if drawn is not None:
+                mappable = drawn
+            for xv in comp["xrefs"]:
+                ax.axvline(xv, color="0.45", ls=":", lw=1.0, zorder=3)
+            for yv in comp["yrefs"]:
+                ax.axhline(yv, color="0.45", ls=":", lw=1.0, zorder=3)
+            if comp["kx_vline"] and scan["kx_upper"] is not None:
+                ax.axvline(
+                    scan["kx_upper"], color="0.3", ls="--", lw=1.0, zorder=3, alpha=0.5
+                )
+            if comp["xlim"] is not None:
+                ax.set_xlim(*comp["xlim"])
+            if comp["ylim"] is not None:
+                ax.set_ylim(*comp["ylim"])
+            ax.tick_params(labelsize=FS_TICK - 2)
+            if r == 0:
+                ax.set_title(scan["label"], fontsize=FS_LABEL)
+            if c == 0:
+                ax.set_ylabel(comp["ylabel"], fontsize=FS_LABEL - 1)
+            ax.set_xlabel(comp["xlabel"], fontsize=FS_LABEL - 1)
+    for row in axes:
+        _sync_row(row)
+    return fig, axes, mappable
+
+
+# Color every point by the gain of the scan named in that scan's "gain_ref": its own gain used
+# directly, or another scan's gain mapped onto these coordinates by pair key (unmatched pairs get
+# NaN -> gray). Pointing the tight scan at the loose scan shows where the loose-bound-synergistic
+# pairs land once Kx* is capped. The direct self-reference path matters for asymmetric-valency
+# scans, which optimize both receptor orderings per pair (two distinct designs): pair_key sorts the
+# receptors, so routing such a scan's own gain through the key would collapse those orderings onto
+# one key. Cross-scan mapping still requires the reference scan's keys to be unique.
+scan_colors_gain = {}
+for scan in SCANS:
+    label, ref = scan["label"], scan["gain_ref"]
+    if ref == label:
+        scan_colors_gain[label] = pair_dfs[label]["log2_gain"].to_numpy()
+        continue
+    ref_gain = pd.Series(
+        pair_dfs[ref]["log2_gain"].to_numpy(), index=pair_key(pair_dfs[ref])
+    )
+    assert ref_gain.index.is_unique, (
+        f"Duplicate pair keys in reference scan {ref!r}; cannot map its gain across scans."
+    )
+    scan_colors_gain[label] = ref_gain.reindex(pair_key(pair_dfs[label])).to_numpy()
+
+gain_norm = Normalize(vmin=0, vmax=GAIN_COLOR_MAX)
+
+
+def draw_gain_points(ax, x, y, cvals):
+    """Gray context cloud plus a Reds overlay of the pairs synergistic in the reference scan."""
+    ax.scatter(
+        x, y, s=3, alpha=0.4, color="0.82", linewidths=0, rasterized=True, zorder=1
+    )
+    synergistic = (
+        cvals > 0
+    )  # NaN (unmatched) is False here, so those stay in the gray cloud
+    order = np.argsort(cvals[synergistic])  # strongest synergy drawn last
+    return ax.scatter(
+        x[synergistic][order],
+        y[synergistic][order],
+        c=cvals[synergistic][order],
+        cmap="Reds",
+        norm=gain_norm,
+        s=5,
+        alpha=0.9,
+        linewidths=0,
+        rasterized=True,
+        zorder=2,
+    )
+
+
+fig, axes, mappable = build_comparison_grid(scan_colors_gain, draw_gain_points)
+fig.colorbar(
+    mappable,
+    ax=axes.ravel().tolist(),
+    label="log2 selectivity gain, reference scan  (gray = none)",
+    fraction=0.03,
+    pad=0.02,
+)
+plt.show()
+```
+
+```{python}
+#| label: fig-scatter-grid-celltype
+# ── The same scatter grid, colored by cell type ───────────────────────────────
+# Identical layout to fig-scatter-grid (rows = comparisons, cols = scans), reusing its
+# machinery, but every pair is colored by its cell type instead of by gain. This exposes which
+# cell types occupy which regions — e.g. whether particular cell types drive the high-Kx*,
+# high-selectivity population or the affinity-ceiling band. With 31 overlapping cell types the
+# view is necessarily dense; it is meant for spotting per-cell-type structure, not exact counts.
+
+from matplotlib.patches import Patch
+
+CELL_TYPES = sorted(
+    set().union(*(pair_dfs[scan["label"]]["Cell_Type"].unique() for scan in SCANS))
+)
+# tab20 + tab20b together give enough distinct qualitative colors for all cell types.
+_qual_colors = list(plt.get_cmap("tab20").colors) + list(plt.get_cmap("tab20b").colors)
+CT_COLORS = _qual_colors[: len(CELL_TYPES)]
+ct_code = {ct: i for i, ct in enumerate(CELL_TYPES)}
+CT_COLOR_ARRAY = np.array(CT_COLORS)
+scan_colors_ct = {
+    scan["label"]: pair_dfs[scan["label"]]["Cell_Type"].map(ct_code).to_numpy()
+    for scan in SCANS
+}
+_ct_rng = np.random.default_rng(0)
+
+
+def draw_celltype_points(ax, x, y, codes):
+    """Scatter every pair colored by its cell type, draw order shuffled so no type dominates."""
+    perm = _ct_rng.permutation(len(x))
+    ax.scatter(
+        x[perm],
+        y[perm],
+        c=CT_COLOR_ARRAY[codes[perm]],
+        s=3,
+        alpha=0.5,
+        linewidths=0,
+        rasterized=True,
+    )
+    return None
+
+
+fig, axes, _ = build_comparison_grid(scan_colors_ct, draw_celltype_points)
+fig.legend(
+    handles=[
+        Patch(facecolor=CT_COLORS[i], label=CELL_TYPES[i])
+        for i in range(len(CELL_TYPES))
+    ],
+    loc="center left",
+    bbox_to_anchor=(1.0, 0.5),
+    ncol=1,
+    fontsize=FS_LEGEND - 2,
+    frameon=False,
+    title="Cell type",
+)
+plt.show()
+```
+
+```{python}
+#| label: fig-copinning
+# ── Co-pinning flow: how pairs move between constraint categories ──────────────
+# Kx* and target affinity are compensatory avidity sources, so a pair that has maxed both
+# has no headroom left — it is genuinely constrained by the Kx* bound. Each pair is labeled
+# by whether it is pinned at its scan's Kx* upper bound and whether either target arm sits at
+# the affinity ceiling, giving four categories. Pairs are matched across scans (cell type +
+# sorted receptor pair), and the alluvial shows how the loose-bound categories redistribute
+# under the tight bound. Ribbons are colored by source category, so each destination block's
+# composition reveals where its pairs were pulled from.
+
+from matplotlib.patches import Rectangle
+
+CAT_NAMES = ["Both interior", "Aff ceiling only", "Kx* pinned only", "Doubly pinned"]
+CAT_COLORS = ["#B4B4B4", "#E8A33D", "#4DAF9A", "#C0392B"]
+
+
+def classify_copinning(df, kx_upper):
+    """Label each pair by constraint category and build a cross-scan matching key.
+
+    Category codes: 0 both interior, 1 aff ceiling only, 2 Kx* pinned only, 3 doubly pinned.
+    The key (cell type + sorted receptor pair) identifies the same pair across scans.
+    """
+    kx_pinned = (np.abs(df["Kx_star"] - kx_upper) < PIN_TOL).to_numpy()
+    aff_ceiling = (
+        np.maximum(df["Affinity_Receptor_1"], df["Affinity_Receptor_2"])
+        > AFFINITY_OPT_BOUNDS[1] - AFF_CEIL_EPS
+    ).to_numpy()
+    return pd.DataFrame(
+        {
+            "key": pair_key(df),
+            "cat": 2 * kx_pinned.astype(int) + aff_ceiling.astype(int),
+        }
+    )
+
+
+def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03):
+    """Alluvial flow between two scans' category assignments.
+
+    Left blocks are source-scan categories, right blocks destination-scan categories, with
+    heights proportional to pair counts. Ribbons are colored by source category so each
+    destination block's composition shows where its pairs came from.
+    """
+    total = trans.sum()
+    n_cat = trans.shape[0]
+    size_left, size_right = trans.sum(axis=1), trans.sum(axis=0)
+    usable = 1 - gap * (n_cat - 1)
+
+    def block_edges(sizes):
+        edges, top = [], 1.0
+        for s in sizes:
+            height = s / total * usable
+            edges.append((top, top - height))
+            top -= height + gap
+        return edges
+
+    left_edges, right_edges = block_edges(size_left), block_edges(size_right)
+    for edges, x0 in [(left_edges, -bar_w), (right_edges, 1.0)]:
+        for cat, (top, bot) in enumerate(edges):
+            ax.add_patch(
+                Rectangle(
+                    (x0, bot),
+                    bar_w,
+                    top - bot,
+                    color=colors[cat],
+                    ec="white",
+                    lw=0.5,
+                    zorder=3,
+                )
+            )
+
+    left_cursor = [top for top, _ in left_edges]
+    right_cursor = [top for top, _ in right_edges]
+    xs = np.linspace(0, 1, 60)
+    ease = (1 - np.cos(np.pi * xs)) / 2
+    for a in range(n_cat):
+        for b in range(n_cat):
+            if trans[a, b] == 0:
+                continue
+            height = trans[a, b] / total * usable
+            l_top, l_bot = left_cursor[a], left_cursor[a] - height
+            r_top, r_bot = right_cursor[b], right_cursor[b] - height
+            left_cursor[a], right_cursor[b] = l_bot, r_bot
+            ax.fill_between(
+                xs,
+                l_bot + (r_bot - l_bot) * ease,
+                l_top + (r_top - l_top) * ease,
+                color=colors[a],
+                alpha=0.45,
+                lw=0,
+                zorder=1,
+            )
+
+    for edges, dx, ha in [
+        (left_edges, -bar_w - 0.015, "right"),
+        (right_edges, 1.0 + bar_w + 0.015, "left"),
+    ]:
+        sizes = size_left if ha == "right" else size_right
+        for cat, (top, bot) in enumerate(edges):
+            if sizes[cat] / total > 0.01:
+                ax.text(
+                    dx,
+                    (top + bot) / 2,
+                    f"{sizes[cat] / total * 100:.0f}%",
+                    ha=ha,
+                    va="center",
+                    fontsize=FS_ANNOT,
+                )
+    ax.set_xlim(-0.22, 1.22)
+    ax.set_ylim(-0.02, 1.09)
+    ax.axis("off")
+
+
+# Flow from the first (loosest) to the second (tightest) scan.
+scan_a, scan_b = SCANS[0], SCANS[1]
+cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
+cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
+matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+cats = range(len(CAT_NAMES))
+trans = (
+    pd.crosstab(matched["cat_a"], matched["cat_b"])
+    .reindex(index=cats, columns=cats, fill_value=0)
+    .to_numpy()
+)
+
+fig, ax = plt.subplots(figsize=(9, 7))
+draw_category_flow(ax, trans, CAT_COLORS)
+ax.text(
+    0,
+    1.07,
+    scan_a["label"],
+    ha="center",
+    va="bottom",
+    fontsize=FS_LABEL,
+    fontweight="bold",
+)
+ax.text(
+    1,
+    1.07,
+    scan_b["label"],
+    ha="center",
+    va="bottom",
+    fontsize=FS_LABEL,
+    fontweight="bold",
+)
+ax.legend(
+    handles=[
+        Patch(facecolor=CAT_COLORS[i], label=CAT_NAMES[i])
+        for i in range(len(CAT_NAMES))
+    ],
+    loc="lower center",
+    bbox_to_anchor=(0.5, -0.06),
+    ncol=len(CAT_NAMES),
+    fontsize=FS_LEGEND,
+    frameon=False,
+)
+plt.tight_layout()
+plt.show()
+```

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -107,65 +107,6 @@ SCANS = [
         "color": "#FF7F00",
         "gain_ref": "Mixed Valency Kx* upper bound 1e-5",
     },
-    # # Specified signal receptor scan
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260604_selec_scan_full_sigCD122.csv",
-    #     "label": "Signal CD122 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#A020F0",
-    #     "gain_ref": "Signal CD122 Kx* upper bound 1e-5",
-    # },
-    # # Count normalization scans
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/old_scan_results/old_tight_kx_bound/20260714_selec_scan_full_norm.csv",
-    #     "label": "Normalized Kx* upper bound 1e-9",
-    #     "kx_upper": -9.0,
-    #     "color": "#4B0082",
-    #     "gain_ref": "Normalized Kx* upper bound 1e-9",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260723_selec_scan_full_norm_filt_kxup.csv",
-    #     "label": "Normalized 1000 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#FF7F00",
-    #     "gain_ref": "Normalized 1000 Kx* upper bound 1e-5",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260804_selec_scan_full_norm_filt_100.csv",
-    #     "label": "Normalized 100 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#4E9A06",
-    #     "gain_ref": "Normalized 100 Kx* upper bound 1e-5",
-    # },
-    # # Variable filter-strength scans
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt3.csv",
-    #     "label": "Filtered 3.0 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#4B0082",
-    #     "gain_ref": "Filtered 3.0 Kx* upper bound 1e-5",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt2.csv",
-    #     "label": "Filtered 2.0 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#FF7F00",
-    #     "gain_ref": "Filtered 2.0 Kx* upper bound 1e-5",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt1-5.csv",
-    #     "label": "Filtered 1.5 Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#4E9A06",
-    #     "gain_ref": "Filtered 1.5 Kx* upper bound 1e-5",
-    # },
-    # {
-    #     "path": "/home/sama/receptor_sweep_data/old_scan_results/20260520_selec_scan_full_filt.csv",
-    #     "label": "Filtered Kx* upper bound 1e-5",
-    #     "kx_upper": -5.0,
-    #     "color": "#CF4D6F",
-    #     "gain_ref": "Filtered Kx* upper bound 1e-5",
-    # },
 ]
 
 # Scans analyzed by fig-kxstar-dist, fig-affinity-dist, fig-selectivity-dist, fig-gain-dist,

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -18,6 +18,8 @@ A reference-only consolidated scatter grid (`fig-scatter-grid`) follows, gatheri
 
 Finally, a co-pinning flow panel (`fig-copinning`) labels each pair by whether it is pinned at its Kx* upper bound and whether a target arm sits at the affinity ceiling (four categories: both interior, aff ceiling only, Kx* pinned only, doubly pinned). Pairs are matched across scans and an alluvial diagram shows how the loose-bound categories redistribute under the tight bound — revealing which pool each constrained category is pulled from.
 
+A second alluvial (`fig-selgain-flow`) reuses the same flow machinery to track a different quadrant: each pair is labeled by selectivity (below/above `SELEC_HIGH_CUTOFF`) crossed with selectivity gain (non-synergistic/synergistic, i.e. `log2_gain <= 0` vs `> 0`), and pairs are matched between the monovalent and bivalent scans to show which quadrant increased valency pulls each pair into — in particular, whether low-selectivity, high-gain pairs move into the high-selectivity, high-gain quadrant.
+
 # Inputs
 - `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory. `SCANS` includes scans beyond the two analyzed by the older figures (e.g. the high-valency scans) — see `ACTIVE_SCAN_LABELS`; the remaining entries are commented-out alternate scan configs (signal-receptor, normalization, filter-strength variants) kept for reference.
 - `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` (by label) analyzed by `fig-kxstar-dist`, `fig-affinity-dist`, `fig-selectivity-dist`, `fig-gain-dist`, and `fig-scatter-grid`. `NEW_ANALYSES` is not restricted to this subset — any scan in `SCANS` can be referenced by `scan_label`.
@@ -37,6 +39,11 @@ Finally, a co-pinning flow panel (`fig-copinning`) labels each pair by whether i
 - **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain (bispecific / max constituent monospecific); gain > 1 is synergy
 - **`fig-scatter-grid`** (reference/diagnostic): rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
 - **`fig-copinning`**: cross-scan alluvial flow of pairs between four constraint categories (Kx*-pinned × target-affinity-ceiling), showing where each tight-bound category is pulled from
+- **`fig-copinning-legend`**: standalone legend for `fig-copinning`'s constraint categories, detached per `fig-celltype-legend`.
+- **`fig-selgain-flow`**: cross-scan (monovalent → bivalent) alluvial flow of pairs between four selectivity × gain quadrants, showing which quadrant increased valency pulls each pair into
+- **`fig-selgain-pos-flow`**: same as `fig-selgain-flow`, restricted to pairs gain+ in the monovalent or bivalent scan (`gain_positive_only=True`), so the (otherwise tiny) gain+ population's own selectivity movement isn't diluted by the much larger gain- bulk
+- **`fig-selgain-flow-legend`**: standalone legend for `fig-selgain-flow`'s selectivity/gain quadrants, detached per `fig-celltype-legend`. Shared by `fig-selgain-pos-flow` and both `-poster` variants below, which use the same four quadrants.
+- **`fig-selgain-flow-poster`** / **`fig-selgain-pos-flow-poster`**: same data as `fig-selgain-flow` / `fig-selgain-pos-flow`, drawn with `vertical=True` (source scan on top, destination on bottom, ribbons flowing top-to-bottom) for a wide/short poster slot instead of the default left-to-right layout.
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
@@ -57,6 +64,7 @@ from bicytok.figure_styles import (
     POINT_SIZE_BACKGROUND,
     POINT_SIZE_XS,
     apply_style,
+    set_tick_count,
 )
 
 apply_style()
@@ -75,7 +83,6 @@ SCANS = [
         "color": "#2774AE",
         "gain_ref": "Kx* upper bound 1e-5",
     },
-
     # Tight Kx* bound scan
     {
         "path": "/home/sama/receptor_sweep_data/20260720_selec_scan_rand42_prot1.csv",
@@ -84,7 +91,6 @@ SCANS = [
         "color": "#CF4D6F",
         "gain_ref": "Kx* upper bound 1e-5",
     },
-
     # High-valency scans. Not in ACTIVE_SCAN_LABELS below, so excluded from the old
     # distribution/grid figures; available to NEW_ANALYSES via scan_label.
     {
@@ -101,7 +107,6 @@ SCANS = [
         "color": "#FF7F00",
         "gain_ref": "Mixed Valency Kx* upper bound 1e-5",
     },
-
     # # Specified signal receptor scan
     # {
     #     "path": "/home/sama/receptor_sweep_data/20260604_selec_scan_full_sigCD122.csv",
@@ -110,7 +115,6 @@ SCANS = [
     #     "color": "#A020F0",
     #     "gain_ref": "Signal CD122 Kx* upper bound 1e-5",
     # },
-
     # # Count normalization scans
     # {
     #     "path": "/home/sama/receptor_sweep_data/old_scan_results/old_tight_kx_bound/20260714_selec_scan_full_norm.csv",
@@ -133,7 +137,6 @@ SCANS = [
     #     "color": "#4E9A06",
     #     "gain_ref": "Normalized 100 Kx* upper bound 1e-5",
     # },
-
     # # Variable filter-strength scans
     # {
     #     "path": "/home/sama/receptor_sweep_data/20260520_selec_scan_full_filt3.csv",
@@ -168,14 +171,21 @@ SCANS = [
 # Scans analyzed by fig-kxstar-dist, fig-affinity-dist, fig-selectivity-dist, fig-gain-dist,
 # and fig-scatter-grid. SCANS may hold other scans (e.g. the high-valency ones above) that are
 # loaded and available to NEW_ANALYSES by scan_label but excluded from these older figures.
-ACTIVE_SCAN_LABELS = ["Kx* upper bound 1e-5", "Kx* upper bound 1e-9"]
+ACTIVE_SCAN_LABELS = [
+    "Kx* upper bound 1e-5",
+    "Kx* upper bound 1e-9",
+    "Bivalent Kx* upper bound 1e-5",
+]
 ACTIVE_SCANS = [s for s in SCANS if s["label"] in ACTIVE_SCAN_LABELS]
 
 # True affinity optimization bounds, log10(M), used for pin/ceiling logic. AFFINITY_BOUNDS pads
 # these for display so points and bars sitting exactly at a bound are not clipped at the spine.
 AFFINITY_OPT_BOUNDS = (6.0, 12.0)
 AFFINITY_BOUNDS = (5.9, 12.1)
-SELEC_BOUNDS = (0.47, 1.02)  # pair selectivity display range, away from the ~0.5 no-selectivity floor
+SELEC_BOUNDS = (
+    0.47,
+    1.02,
+)  # pair selectivity display range, away from the ~0.5 no-selectivity floor
 
 # Affinity CSV columns mapped to their receptor role (order = subpanel order).
 AFF_COLS = {
@@ -192,6 +202,8 @@ SIGNAL_REC_NAME = "Prototype_Signal_Receptor"
 # AFF_CEIL_EPS of the optimization ceiling counts as sitting "at the ceiling".
 PIN_TOL = 1e-2
 AFF_CEIL_EPS = 1e-2
+
+RASTERIZE = True
 
 
 # ── Curated single-panel analyses (manuscript/SVG extraction) ──────────────────
@@ -317,7 +329,9 @@ def pair_key(df):
 # ── Comparison shapes: x/y axes, reference lines, limits ──────────────────────
 SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
 GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
-LOG_Y_GAIN_FLOOR = 1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
+LOG_Y_GAIN_FLOOR = (
+    1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
+)
 KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
 GAIN_YLABEL = r"log$_{2}$ selectivity gain"
 SELECTIVITY_XLABEL = "Binding model selectivity"
@@ -375,7 +389,9 @@ def _sel_vs(xkey):
 # One row per comparison. xrefs/yrefs are gray reference lines; kx_vline draws each scan's Kx*
 # upper bound; ylim fixes the display range (affinity panels use padded bounds). _row supplies the
 # shared defaults so each entry states only what differs.
-def _row(get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vline=False):
+def _row(
+    get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vline=False
+):
     return dict(
         get=get,
         xlabel=xlabel,
@@ -389,7 +405,9 @@ def _row(get, xlabel, ylabel, *, xlim=None, ylim=None, xrefs=(), yrefs=(), kx_vl
 
 
 COMPARISON_SHAPES = {
-    "sel_vs_kx": _row(_vs_kxstar("sel"), KX_XLABEL, SELECTIVITY_XLABEL, yrefs=(0.5,), kx_vline=True),
+    "sel_vs_kx": _row(
+        _vs_kxstar("sel"), KX_XLABEL, SELECTIVITY_XLABEL, yrefs=(0.5,), kx_vline=True
+    ),
     "sig_aff_vs_kx": _row(
         _vs_kxstar("aff0"),
         KX_XLABEL,
@@ -445,7 +463,6 @@ COMPARISON_SHAPES = {
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-
     # Used only by NEW_ANALYSES single-panel extracts, not the bulk reference grid (see
     # GRID_COMPARISON_KEYS): sel_vs_kx_loose fixes the y-axis to SELEC_BOUNDS (rather than
     # auto-scaling) so it matches sel_vs_targ1_aff's y-axis for side-by-side placement.
@@ -528,7 +545,9 @@ ALL_CELL_TYPES = sorted(
 )
 
 
-def draw_gain_points(ax, x, y, cvals, point_size_bg=GRID_POINT_SIZE_BG, point_size_fg=GRID_POINT_SIZE_FG):
+def draw_gain_points(
+    ax, x, y, cvals, point_size_bg=GRID_POINT_SIZE_BG, point_size_fg=GRID_POINT_SIZE_FG
+):
     """Gray context cloud plus a Reds overlay of the pairs synergistic in the reference scan."""
     ax.scatter(
         x,
@@ -537,7 +556,7 @@ def draw_gain_points(ax, x, y, cvals, point_size_bg=GRID_POINT_SIZE_BG, point_si
         alpha=0.4,
         color="0.82",
         linewidths=0,
-        rasterized=True,
+        rasterized=RASTERIZE,
         zorder=1,
     )
     synergistic = (
@@ -553,7 +572,7 @@ def draw_gain_points(ax, x, y, cvals, point_size_bg=GRID_POINT_SIZE_BG, point_si
         s=point_size_fg,
         alpha=0.9,
         linewidths=0,
-        rasterized=True,
+        rasterized=RASTERIZE,
         zorder=2,
     )
 
@@ -572,7 +591,7 @@ def draw_celltype_points(ax, x, y, cell_types, point_size=GRID_POINT_SIZE_FG):
         s=point_size,
         alpha=0.6,
         linewidths=0,
-        rasterized=True,
+        rasterized=RASTERIZE,
     )
 
 
@@ -610,9 +629,7 @@ def _draw_comparison_panel(
     for yv in comp["yrefs"]:
         ax.axhline(yv, color="0.45", ls=":", lw=1.0, zorder=3)
     if comp["kx_vline"] and scan["kx_upper"] is not None:
-        ax.axvline(
-            scan["kx_upper"], color="0.3", ls="--", lw=1.0, zorder=3, alpha=0.5
-        )
+        ax.axvline(scan["kx_upper"], color="0.3", ls="--", lw=1.0, zorder=3, alpha=0.5)
     if comp["xlim"] is not None:
         ax.set_xlim(*comp["xlim"])
     if comp["ylim"] is not None:
@@ -670,6 +687,9 @@ def plot_new_analysis(key):
             fraction=COLORBAR_FRACTION,
             pad=COLORBAR_PAD,
         )
+
+    set_tick_count(ax, 3, None)
+
     plt.tight_layout()
     plt.show()
 ```
@@ -718,7 +738,9 @@ _celltype_legend_handles = [
     mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
     for ct in ALL_CELL_TYPES
 ]
-standalone_legend_figure(_celltype_legend_handles, ALL_CELL_TYPES, ncol=2, title="Cell type")
+standalone_legend_figure(
+    _celltype_legend_handles, ALL_CELL_TYPES, ncol=2, title="Cell type"
+)
 plt.show()
 ```
 
@@ -999,10 +1021,19 @@ plot_comparison_grid()
 
 from matplotlib.patches import Patch, Rectangle
 
-from bicytok.figure_styles import FONT_SIZE_TITLE
+from bicytok.figure_styles import FONT_SIZE_LABEL, standalone_legend_figure
 
-CAT_NAMES = ["Both interior", "Aff ceiling only", "Kx* pinned only", "Doubly pinned"]
-CAT_COLORS = ["#B4B4B4", "#E8A33D", "#4DAF9A", "#C0392B"]
+# Shared palette for both flow figures below (see CROSSED_CONDITION_COLORS: reused from
+# scan_outliers.qmd's outlier categories, which have the same neither/A-only/B-only/both
+# shape): index 0 is "neither condition", 3 is "both conditions", 1/2 are each condition
+# alone (see each category-name list for the specific conditions).
+FLOW_CAT_COLORS = CROSSED_CONDITION_COLORS
+COPINNING_CAT_NAMES = [
+    "Both interior",
+    "Aff ceiling only",
+    "Kx* pinned only",
+    "Doubly pinned",
+]
 
 
 def classify_copinning(df, kx_upper):
@@ -1024,16 +1055,54 @@ def classify_copinning(df, kx_upper):
     )
 
 
-def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03):
+# Selectivity/gain flow quadrant thresholds below (fig-selgain-flow). SELEC_HIGH_CUTOFF is
+# distinct from SELEC_FLOOR, which marks the ~0.5 no-selectivity floor used elsewhere in this
+# file; this cutoff instead marks pairs selective enough to be manuscript-relevant.
+# GAIN_HIGH_CUTOFF is a log2 gain threshold; 0 (the default) is the synergy line used
+# elsewhere in this file (bispecific beats the better monospecific constituent), but both
+# cutoffs are also exposed as build_selgain_flow/plot_selgain_flow arguments so they can be
+# tuned to isolate a specific population (e.g. pairs only reaching meaningful gain at
+# high valency) without editing these module-level defaults.
+SELEC_HIGH_CUTOFF = 0.91
+GAIN_HIGH_CUTOFF = 0.0
+SEL_GAIN_CAT_NAMES = [
+    "Low selectivity, gain-",
+    "Low selectivity, gain+",
+    "High selectivity, gain-",
+    "High selectivity, gain+",
+]
+
+
+def classify_selectivity_gain(df, selec_cutoff, gain_cutoff):
+    """Label each pair by selectivity/gain quadrant and build a cross-scan matching key.
+
+    Category codes: 0 low selectivity & gain <= gain_cutoff, 1 low selectivity &
+    gain > gain_cutoff, 2 high selectivity & gain <= gain_cutoff, 3 high selectivity &
+    gain > gain_cutoff.
+    """
+    high_sel = (df["Selectivity"] >= selec_cutoff).to_numpy()
+    high_gain = (df["log2_gain"] > gain_cutoff).to_numpy()
+    return pd.DataFrame(
+        {
+            "key": pair_key(df),
+            "cat": 2 * high_sel.astype(int) + high_gain.astype(int),
+        }
+    )
+
+
+def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03, vertical=False):
     """Alluvial flow between two scans' category assignments.
 
-    Left blocks are source-scan categories, right blocks destination-scan categories, with
-    heights proportional to pair counts. Ribbons are colored by source category so each
-    destination block's composition shows where its pairs came from.
+    Source-scan and destination-scan blocks sit at opposite ends of the flow axis, sized
+    proportional to pair counts; ribbons connect them, colored by source category so each
+    destination block's composition shows where its pairs came from. By default the flow
+    axis is x (source left, destination right, flowing left-to-right) and blocks are stacked
+    along y; vertical=True swaps these (source top, destination bottom, flowing top-to-bottom,
+    blocks laid out along x) for a wide/short footprint, e.g. a poster panel.
     """
     total = trans.sum()
     n_cat = trans.shape[0]
-    size_left, size_right = trans.sum(axis=1), trans.sum(axis=0)
+    size_a, size_b = trans.sum(axis=1), trans.sum(axis=0)
     usable = 1 - gap * (n_cat - 1)
 
     def block_edges(sizes):
@@ -1044,69 +1113,95 @@ def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03):
             top -= height + gap
         return edges
 
-    left_edges, right_edges = block_edges(size_left), block_edges(size_right)
-    for edges, x0 in [(left_edges, -bar_w), (right_edges, 1.0)]:
-        for cat, (top, bot) in enumerate(edges):
-            ax.add_patch(
-                Rectangle(
-                    (x0, bot),
-                    bar_w,
-                    top - bot,
-                    color=colors[cat],
-                    ec="white",
-                    lw=0.5,
-                    zorder=3,
-                )
-            )
+    edges_a, edges_b = block_edges(size_a), block_edges(size_b)
 
-    left_cursor = [top for top, _ in left_edges]
-    right_cursor = [top for top, _ in right_edges]
+    if vertical:
+        for edges, y0 in [(edges_a, 1.0), (edges_b, -bar_w)]:
+            for cat, (top, bot) in enumerate(edges):
+                ax.add_patch(
+                    Rectangle(
+                        (bot, y0),
+                        top - bot,
+                        bar_w,
+                        color=colors[cat],
+                        ec="white",
+                        lw=0.5,
+                        zorder=3,
+                    )
+                )
+    else:
+        for edges, x0 in [(edges_a, -bar_w), (edges_b, 1.0)]:
+            for cat, (top, bot) in enumerate(edges):
+                ax.add_patch(
+                    Rectangle(
+                        (x0, bot),
+                        bar_w,
+                        top - bot,
+                        color=colors[cat],
+                        ec="white",
+                        lw=0.5,
+                        zorder=3,
+                    )
+                )
+
+    cursor_a = [top for top, _ in edges_a]
+    cursor_b = [top for top, _ in edges_b]
     xs = np.linspace(0, 1, 60)
     ease = (1 - np.cos(np.pi * xs)) / 2
+    flow_axis = 1 - xs if vertical else xs  # vertical flows top (1) to bottom (0)
     for a in range(n_cat):
         for b in range(n_cat):
             if trans[a, b] == 0:
                 continue
             height = trans[a, b] / total * usable
-            l_top, l_bot = left_cursor[a], left_cursor[a] - height
-            r_top, r_bot = right_cursor[b], right_cursor[b] - height
-            left_cursor[a], right_cursor[b] = l_bot, r_bot
-            ax.fill_between(
-                xs,
-                l_bot + (r_bot - l_bot) * ease,
-                l_top + (r_top - l_top) * ease,
-                color=colors[a],
-                alpha=0.45,
-                lw=0,
-                zorder=1,
+            l_top, l_bot = cursor_a[a], cursor_a[a] - height
+            r_top, r_bot = cursor_b[b], cursor_b[b] - height
+            cursor_a[a], cursor_b[b] = l_bot, r_bot
+            lower = l_bot + (r_bot - l_bot) * ease
+            upper = l_top + (r_top - l_top) * ease
+            fill = ax.fill_betweenx if vertical else ax.fill_between
+            fill(flow_axis, lower, upper, color=colors[a], alpha=0.45, lw=0, zorder=1)
+
+    if vertical:
+        label_spots = [
+            (edges_a, 1.0 + bar_w + 0.015, "bottom"),
+            (edges_b, -bar_w - 0.015, "top"),
+        ]
+    else:
+        label_spots = [
+            (edges_a, -bar_w - 0.015, "right"),
+            (edges_b, 1.0 + bar_w + 0.015, "left"),
+        ]
+    for edges, off, align in label_spots:
+        sizes = size_a if edges is edges_a else size_b
+        for cat, (top, bot) in enumerate(edges):
+            if sizes[cat] / total <= 0.01:
+                continue
+            center = (top + bot) / 2
+            pos, kwargs = (
+                ((center, off), {"ha": "center", "va": align})
+                if vertical
+                else ((off, center), {"ha": align, "va": "center"})
+            )
+            ax.text(
+                *pos,
+                f"{sizes[cat] / total * 100:.0f}%",
+                fontsize=FONT_SIZE_ANNOT,
+                **kwargs,
             )
 
-    for edges, dx, ha in [
-        (left_edges, -bar_w - 0.015, "right"),
-        (right_edges, 1.0 + bar_w + 0.015, "left"),
-    ]:
-        sizes = size_left if ha == "right" else size_right
-        for cat, (top, bot) in enumerate(edges):
-            if sizes[cat] / total > 0.01:
-                ax.text(
-                    dx,
-                    (top + bot) / 2,
-                    f"{sizes[cat] / total * 100:.0f}%",
-                    ha=ha,
-                    va="center",
-                    fontsize=FONT_SIZE_ANNOT,
-                )
-    ax.set_xlim(-0.22, 1.22)
-    ax.set_ylim(-0.02, 1.09)
+    if vertical:
+        ax.set_xlim(-0.02, 1.09)
+        ax.set_ylim(-0.34, 1.34)
+    else:
+        ax.set_xlim(-0.22, 1.22)
+        ax.set_ylim(-0.02, 1.09)
     ax.axis("off")
 
 
-def build_copinning_flow(scan_a, scan_b):
-    """Compute the co-pinning category transition matrix between two scans."""
-    cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
-    cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
-    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
-    cats = range(len(CAT_NAMES))
+def transition_from_matched(matched, n_cat):
+    """Category transition matrix from an already cats_a/cats_b-merged pair table."""
+    cats = range(n_cat)
     return (
         pd.crosstab(matched["cat_a"], matched["cat_b"])
         .reindex(index=cats, columns=cats, fill_value=0)
@@ -1114,45 +1209,154 @@ def build_copinning_flow(scan_a, scan_b):
     )
 
 
+def pairs_to_transition(cats_a, cats_b, n_cat):
+    """Cross-scan category transition matrix from two classified pair tables (key, cat)."""
+    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+    return transition_from_matched(matched, n_cat)
+
+
+def build_copinning_flow(scan_a, scan_b):
+    """Compute the co-pinning category transition matrix between two scans."""
+    cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
+    cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
+    return pairs_to_transition(cats_a, cats_b, len(COPINNING_CAT_NAMES))
+
+
+def build_selgain_flow(
+    scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only=False
+):
+    """Compute the selectivity/gain quadrant transition matrix between two scans.
+
+    gain_positive_only restricts to pairs classified gain+ (categories 1 or 3, i.e.
+    cat % 2 == 1) in scan_a or scan_b. The gain+ population is a small fraction of all
+    pairs, so without this the transition percentages are dominated by gain- pairs sitting
+    still; restricting to "ever gain+" pairs makes the gain+ population's own selectivity
+    movement legible instead of being diluted by the much larger gain- bulk.
+    """
+    cats_a = classify_selectivity_gain(
+        pair_dfs[scan_a["label"]], selec_cutoff, gain_cutoff
+    )
+    cats_b = classify_selectivity_gain(
+        pair_dfs[scan_b["label"]], selec_cutoff, gain_cutoff
+    )
+    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
+    if gain_positive_only:
+        matched = matched[(matched["cat_a"] % 2 == 1) | (matched["cat_b"] % 2 == 1)]
+    return transition_from_matched(matched, len(SEL_GAIN_CAT_NAMES))
+
+
+def plot_flow(trans, label_a, label_b, vertical=False):
+    """Draw a category-transition alluvial from label_a to label_b as a standalone figure.
+
+    Shared renderer for fig-copinning and fig-selgain-flow: trans carries the figure-specific
+    data, so this function only knows about the generic category flow, not what a category
+    represents. The legend is detached (see flow_legend_figure), so ribbon colors alone would
+    be ambiguous without it. vertical=True draws source-top/destination-bottom instead of the
+    default source-left/destination-right (see draw_category_flow), for a wide/short footprint.
+    """
+    figsize = FIGSIZE["alluvial_flow_vertical" if vertical else "alluvial_flow"]
+    fig, ax = plt.subplots(figsize=figsize)
+    draw_category_flow(ax, trans, FLOW_CAT_COLORS, vertical=vertical)
+    if vertical:
+        ax.text(0.5, 1.19, label_a, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
+        ax.text(0.5, -0.19, label_b, ha="center", va="top", fontsize=FONT_SIZE_LABEL)
+    else:
+        ax.text(0, 1.07, label_a, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
+        ax.text(1, 1.07, label_b, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
+    plt.tight_layout()
+    plt.show()
+
+
+def flow_legend_figure(cat_names):
+    """Standalone legend mapping FLOW_CAT_COLORS to cat_names, detached per fig-celltype-legend
+    so it can be positioned independently (e.g. in Illustrator) rather than crowding plot_flow.
+    """
+    handles = [Patch(facecolor=FLOW_CAT_COLORS[i]) for i in range(len(cat_names))]
+    return standalone_legend_figure(handles, cat_names, ncol=len(cat_names))
+
+
 def plot_copinning(scan_a, scan_b):
     """Draw the co-pinning alluvial flow from scan_a to scan_b as a standalone figure."""
     trans = build_copinning_flow(scan_a, scan_b)
-    fig, ax = plt.subplots(figsize=(9, 7))
-    draw_category_flow(ax, trans, CAT_COLORS)
-    ax.text(
-        0,
-        1.07,
-        scan_a["label"],
-        ha="center",
-        va="bottom",
-        fontsize=FONT_SIZE_TITLE,
-        fontweight="bold",
+    plot_flow(trans, scan_a["label"], scan_b["label"])
+
+
+def plot_selgain_flow(
+    scan_a,
+    scan_b,
+    selec_cutoff=SELEC_HIGH_CUTOFF,
+    gain_cutoff=GAIN_HIGH_CUTOFF,
+    gain_positive_only=False,
+    vertical=False,
+):
+    """Draw the selectivity/gain quadrant alluvial flow from scan_a to scan_b."""
+    trans = build_selgain_flow(
+        scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only
     )
-    ax.text(
-        1,
-        1.07,
-        scan_b["label"],
-        ha="center",
-        va="bottom",
-        fontsize=FONT_SIZE_TITLE,
-        fontweight="bold",
-    )
-    ax.legend(
-        handles=[
-            Patch(facecolor=CAT_COLORS[i], label=CAT_NAMES[i])
-            for i in range(len(CAT_NAMES))
-        ],
-        loc="lower center",
-        bbox_to_anchor=(0.5, -0.06),
-        ncol=len(CAT_NAMES),
-        frameon=False,
-    )
-    plt.tight_layout()
-    plt.show()
+    plot_flow(trans, scan_a["label"], scan_b["label"], vertical=vertical)
 ```
 
 ```{python}
 #| label: fig-copinning
 # Flow from the first (loosest) to the second (tightest) active scan.
 plot_copinning(ACTIVE_SCANS[0], ACTIVE_SCANS[1])
+```
+
+```{python}
+#| label: fig-copinning-legend
+#| fig-cap: "Shared legend for fig-copinning's constraint categories"
+flow_legend_figure(COPINNING_CAT_NAMES)
+plt.show()
+```
+
+```{python}
+#| label: fig-selgain-flow
+# Flow from the monovalent to the bivalent scan.
+plot_selgain_flow(
+    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
+    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
+    gain_positive_only=False,
+)
+```
+
+```{python}
+#| label: fig-selgain-pos-flow
+# Flow from the monovalent to the bivalent scan.
+plot_selgain_flow(
+    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
+    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
+    gain_positive_only=True,
+    gain_cutoff=0.01,
+)
+```
+
+```{python}
+#| label: fig-selgain-flow-legend
+#| fig-cap: "Shared legend for fig-selgain-flow's selectivity/gain quadrants"
+flow_legend_figure(SEL_GAIN_CAT_NAMES)
+plt.show()
+```
+
+```{python}
+#| label: fig-selgain-flow-poster
+# Same as fig-selgain-flow, rotated (source top / destination bottom, ribbons flowing
+# vertically) for a wide/short poster slot.
+plot_selgain_flow(
+    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
+    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
+    gain_positive_only=False,
+    vertical=True,
+)
+```
+
+```{python}
+#| label: fig-selgain-pos-flow-poster
+# Same as fig-selgain-pos-flow, rotated for a wide/short poster slot.
+plot_selgain_flow(
+    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
+    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
+    gain_positive_only=True,
+    gain_cutoff=0.01,
+    vertical=True,
+)
 ```

--- a/figures/scanning_analyses/scan_kxstar_bounds.qmd
+++ b/figures/scanning_analyses/scan_kxstar_bounds.qmd
@@ -1,30 +1,27 @@
 ---
-title: "Kx* Upper-Bound Effect on Selectivity Scans"
+title: "Optimal Binding-Model Parameter Distributions Across Selectivity Scans"
 ---
 
 # Summary
-Investigates why selectivity scans yield markedly different synergy depending on the upper bound imposed on Kx* during affinity optimization (see `scan_synergy.qmd`). A scan with an upper bound of 1e-5 gives widespread synergy, while an otherwise-identical scan with an upper bound of 1e-9 exhibits limited, low-gain synergy.
+Examines how optimal binding-model parameters — Kx*, the three monomer affinities, selectivity, and a derived selectivity-gain (synergy) metric — are distributed across selectivity scans, and how those distributions shift with the Kx* upper bound imposed during affinity optimization. The file originated as an investigation into why a scan with a loose Kx* upper bound (1e-5) yields widespread synergy while an otherwise-identical scan with a tight bound (1e-9) yields limited, low-gain synergy (see `scan_synergy.qmd`); that loose-vs-tight comparison remains the throughline, but the analysis has broadened to cover per-pair parameter relationships and cross-scan parameter distributions more generally. Cross-scan pair-category flow (which category a pair moves between, rather than a parameter's own distribution) has moved to `scan_alluvial_flows.qmd`.
 
-A curated set of single-panel manuscript figures (`NEW_ANALYSES`) leads the file: each entry picks one pre-built comparison shape (an x/y axis pairing with its reference lines and limits), one scan to draw from, and whether points are colored by log2 selectivity gain or by cell type. `plot_new_analysis(key)` renders one entry as a standalone figure.
+Three complementary analyses appear below, in this order:
 
-After that, four panels aggregate every binding-model output (and a derived synergy gain) over all successfully optimized pairs, across the two `ACTIVE_SCANS`:
-
-1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked. When a large fraction of pairs optimize to Kx* above the tighter bound, that bound pins them at the wall, compressing the high-Kx* population and plausibly suppressing synergy.
-2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs are excluded here because the second target receptor is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
-3. **Selectivity distribution** — optimal selectivity, targ / (targ + off-targ), on a log density axis to reveal the high-selectivity tail above the ~0.5 no-selectivity floor.
-4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy (the pair beats either receptor alone). The signal receptor is excluded here, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
-
-A reference-only consolidated scatter grid (`fig-scatter-grid`) follows, gathering every per-pair scatter into one figure: rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. Points are rasterized (~276k per panel). This grid is kept as a diagnostic reference; it does not include the `NEW_ANALYSES` comparisons above.
-
-Finally, a co-pinning flow panel (`fig-copinning`) labels each pair by whether it is pinned at its Kx* upper bound and whether a target arm sits at the affinity ceiling (four categories: both interior, aff ceiling only, Kx* pinned only, doubly pinned). Pairs are matched across scans and an alluvial diagram shows how the loose-bound categories redistribute under the tight bound — revealing which pool each constrained category is pulled from.
-
-A second alluvial (`fig-selgain-flow`) reuses the same flow machinery to track a different quadrant: each pair is labeled by selectivity (below/above `SELEC_HIGH_CUTOFF`) crossed with selectivity gain (non-synergistic/synergistic, i.e. `log2_gain <= 0` vs `> 0`), and pairs are matched between the monovalent and bivalent scans to show which quadrant increased valency pulls each pair into — in particular, whether low-selectivity, high-gain pairs move into the high-selectivity, high-gain quadrant.
+1. **Specific single-panel figures** (`SPECIFIC_ANALYSES`): each entry picks one pre-built comparison shape (an x/y axis pairing with its reference lines and limits, `COMPARISON_SHAPES`), one scan to draw from, and whether points are colored by log2 selectivity gain or by cell type. `plot_specific_analysis(key)` renders one entry as a standalone figure. The most flexible of the three — any scan in `SCANS` can be plotted against any shape.
+2. **Parameter histograms**: four panels aggregating every binding-model output (and the derived gain) over all successfully optimized pairs, across the two `ACTIVE_SCANS`, showing how each distribution's overall shape (rather than per-pair relationships) responds to the Kx* bound:
+   1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked. When a large fraction of pairs optimize to Kx* above the tighter bound, that bound pins them at the wall, compressing the high-Kx* population and plausibly suppressing synergy.
+   2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs are excluded here because the second target receptor is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
+   3. **Selectivity distribution** — optimal selectivity, targ / (targ + off-targ), on a log density axis to reveal the high-selectivity tail above the ~0.5 no-selectivity floor.
+   4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy (the pair beats either receptor alone). The signal receptor is excluded here, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
+3. **Scatter grid** (`fig-scatter-grid`, reference/diagnostic): a consolidated grid gathering every per-pair scatter, rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. Points are rasterized (~276k per panel). This grid is kept as a diagnostic reference; it does not include the `SPECIFIC_ANALYSES` comparisons above.
 
 # Inputs
-- `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory. `SCANS` includes scans beyond the two analyzed by the older figures (e.g. the high-valency scans) — see `ACTIVE_SCAN_LABELS`; the remaining entries are commented-out alternate scan configs (signal-receptor, normalization, filter-strength variants) kept for reference.
-- `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` (by label) analyzed by `fig-kxstar-dist`, `fig-affinity-dist`, `fig-selectivity-dist`, `fig-gain-dist`, and `fig-scatter-grid`. `NEW_ANALYSES` is not restricted to this subset — any scan in `SCANS` can be referenced by `scan_label`.
-- `NEW_ANALYSES`: dict of curated single-panel figures. Each entry has a `comparison` (a key into `COMPARISON_SHAPES`), a `scan_label` (any scan in `SCANS`), and a `color_by` of `"gain"` (log2 selectivity gain, colorbar, sized via `FIGSIZE["square_scatter_with_colorbar"]`) or `"cell_type"` (shared `CELL_TYPE_COLORS` mapping; legend omitted per panel, see `fig-celltype-legend`).
-- `AFFINITY_BOUNDS`: shared (min, max) affinity optimization bounds in log10(M), drawn as reference lines in the affinity panel.
+All user-facing parameters are collected at the top of the code cell below, ahead of the data loading and plotting mechanics.
+
+- `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory.
+- `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` (by label) analyzed by `fig-kxstar-dist`, `fig-affinity-dist`, `fig-selectivity-dist`, `fig-gain-dist`, and `fig-scatter-grid`. `SPECIFIC_ANALYSES` is not restricted to this subset — any scan in `SCANS` can be referenced by `scan_label`.
+- `SPECIFIC_ANALYSES`: dict of specific single-panel figures. Each entry has a `comparison` (a key into `COMPARISON_SHAPES`), a `scan_label` (any scan in `SCANS`), and a `color_by` of `"gain"` (log2 selectivity gain, colorbar, sized via `FIGSIZE["square_scatter_with_colorbar"]`) or `"cell_type"` (shared `CELL_TYPE_COLORS` mapping; legend omitted per panel, see `fig-celltype-legend`).
+- `AFFINITY_BOUNDS` / `SELEC_BOUNDS`: shared (min, max) display ranges in log10(M) / fraction, drawn as reference lines or axis limits across the affinity and selectivity panels.
 
 # Outputs
 - **`fig-sel-vs-kx-loose`**: Selectivity vs. optimal log10(Kx*), 1e-5 bound scan, colored by cell type. Shares its y-axis range (`SELEC_BOUNDS`) with `fig-sel-vs-targ1aff-loose` for side-by-side manuscript placement.
@@ -38,17 +35,12 @@ A second alluvial (`fig-selgain-flow`) reuses the same flow machinery to track a
 - **`fig-selectivity-dist`**: overlaid log-density histograms of optimal selectivity
 - **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain (bispecific / max constituent monospecific); gain > 1 is synergy
 - **`fig-scatter-grid`** (reference/diagnostic): rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
-- **`fig-copinning`**: cross-scan alluvial flow of pairs between four constraint categories (Kx*-pinned × target-affinity-ceiling), showing where each tight-bound category is pulled from
-- **`fig-copinning-legend`**: standalone legend for `fig-copinning`'s constraint categories, detached per `fig-celltype-legend`.
-- **`fig-selgain-flow`**: cross-scan (monovalent → bivalent) alluvial flow of pairs between four selectivity × gain quadrants, showing which quadrant increased valency pulls each pair into
-- **`fig-selgain-pos-flow`**: same as `fig-selgain-flow`, restricted to pairs gain+ in the monovalent or bivalent scan (`gain_positive_only=True`), so the (otherwise tiny) gain+ population's own selectivity movement isn't diluted by the much larger gain- bulk
-- **`fig-selgain-flow-legend`**: standalone legend for `fig-selgain-flow`'s selectivity/gain quadrants, detached per `fig-celltype-legend`. Shared by `fig-selgain-pos-flow` and both `-poster` variants below, which use the same four quadrants.
-- **`fig-selgain-flow-poster`** / **`fig-selgain-pos-flow-poster`**: same data as `fig-selgain-flow` / `fig-selgain-pos-flow`, drawn with `vertical=True` (source scan on top, destination on bottom, ribbons flowing top-to-bottom) for a wide/short poster slot instead of the default left-to-right layout.
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
 import os
 
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -61,15 +53,21 @@ from bicytok.figure_styles import (
     COLORBAR_FRACTION,
     COLORBAR_PAD,
     FIGSIZE,
+    FONT_SIZE_ANNOT,
     POINT_SIZE_BACKGROUND,
     POINT_SIZE_XS,
     apply_style,
     set_tick_count,
+    standalone_legend_figure,
 )
 
 apply_style()
 
-# ── Scan pools ──────────────────────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════════════
+# Parameters — everything below this line and above "Data loading" is meant to be
+# edited to retarget this file at new scans, thresholds, or display ranges.
+# ═══════════════════════════════════════════════════════════════════════════════
+
 # Each scan's "gain_ref" names the scan (by label) whose per-pair gain colors this scan's points
 # in fig-scatter-grid: its own label uses its own gain; another scan's label maps that scan's gain
 # onto these coordinates (pointing the tight scan at the loose scan reveals where pairs get
@@ -91,8 +89,8 @@ SCANS = [
         "color": "#CF4D6F",
         "gain_ref": "Kx* upper bound 1e-5",
     },
-    # High-valency scans. Not in ACTIVE_SCAN_LABELS below, so excluded from the old
-    # distribution/grid figures; available to NEW_ANALYSES via scan_label.
+    # High-valency scans. Not in ACTIVE_SCAN_LABELS below, so excluded from the
+    # distribution/grid figures; available to SPECIFIC_ANALYSES via scan_label.
     {
         "path": "/home/sama/receptor_sweep_data/20260529_selec_scan_full_bival.csv",
         "label": "Bivalent Kx* upper bound 1e-5",
@@ -111,7 +109,7 @@ SCANS = [
 
 # Scans analyzed by fig-kxstar-dist, fig-affinity-dist, fig-selectivity-dist, fig-gain-dist,
 # and fig-scatter-grid. SCANS may hold other scans (e.g. the high-valency ones above) that are
-# loaded and available to NEW_ANALYSES by scan_label but excluded from these older figures.
+# loaded and available to SPECIFIC_ANALYSES by scan_label but excluded from these figures.
 ACTIVE_SCAN_LABELS = [
     "Kx* upper bound 1e-5",
     "Kx* upper bound 1e-9",
@@ -119,14 +117,11 @@ ACTIVE_SCAN_LABELS = [
 ]
 ACTIVE_SCANS = [s for s in SCANS if s["label"] in ACTIVE_SCAN_LABELS]
 
-# True affinity optimization bounds, log10(M), used for pin/ceiling logic. AFFINITY_BOUNDS pads
-# these for display so points and bars sitting exactly at a bound are not clipped at the spine.
-AFFINITY_OPT_BOUNDS = (6.0, 12.0)
+# Display ranges: affinity in log10(M), padded from the true (6.0, 12.0) optimization bounds
+# so points and bars sitting exactly at a bound are not clipped at the spine; selectivity as a
+# fraction, away from the ~0.5 no-selectivity floor.
 AFFINITY_BOUNDS = (5.9, 12.1)
-SELEC_BOUNDS = (
-    0.47,
-    1.02,
-)  # pair selectivity display range, away from the ~0.5 no-selectivity floor
+SELEC_BOUNDS = (0.47, 1.02)
 
 # Affinity CSV columns mapped to their receptor role (order = subpanel order).
 AFF_COLS = {
@@ -139,20 +134,41 @@ AFF_COLS = {
 # containing the artificial signal receptor is not a genuine two-target combination.
 SIGNAL_REC_NAME = "Prototype_Signal_Receptor"
 
-# Fraction pinned is counted within this log10 tolerance of the bound; a target affinity within
-# AFF_CEIL_EPS of the optimization ceiling counts as sitting "at the ceiling".
+# Fraction pinned (fig-kxstar-dist) is counted within this log10 tolerance of the bound.
 PIN_TOL = 1e-2
-AFF_CEIL_EPS = 1e-2
 
 RASTERIZE = True
 
+# Scatter-panel display tuning, shared by SPECIFIC_ANALYSES and the scatter grid.
+SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
+GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
+LOG_Y_GAIN_FLOOR = (
+    1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
+)
+KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
+GAIN_YLABEL = r"log$_{2}$ selectivity gain"
+SELECTIVITY_XLABEL = "Binding model selectivity"
 
-# ── Curated single-panel analyses (manuscript/SVG extraction) ──────────────────
-# Each entry renders one standalone panel via plot_new_analysis(key): "comparison" names a
-# shape in COMPARISON_SHAPES (x/y axes, reference lines, limits), "scan_label" names any scan
-# in SCANS (not just ACTIVE_SCANS), and "color_by" is "gain" (log2 selectivity gain, colorbar)
-# or "cell_type" (one color per Cell_Type, legend).
-NEW_ANALYSES = {
+# ~276k points per panel in the bulk grid: far denser than the shared point-size constants
+# assume (tuned for scatter plots with far fewer points), so these panels keep their own
+# smaller sizes to stay legible rather than rendering as a solid blob.
+GRID_POINT_SIZE_BG = 3
+GRID_POINT_SIZE_FG = 5
+
+# Scatter grid layout. This grid packs 8 comparisons x len(SCANS) scans into one figure, so
+# its labels use fixed reduced sizes rather than the shared label/tick constants (which would
+# overrun a 4.3x3.0" panel repeated across many subplots).
+PANEL_W, PANEL_H = 4.3, 3.0
+GRID_TITLE_FONTSIZE = 14
+GRID_LABEL_FONTSIZE = 13
+GRID_TICK_FONTSIZE = 10
+
+# Specific single-panel figures (manuscript/SVG extraction), rendered via
+# plot_specific_analysis(key): "comparison" names a shape in COMPARISON_SHAPES (x/y axes,
+# reference lines, limits), "scan_label" names any scan in SCANS (not just ACTIVE_SCANS), and
+# "color_by" is "gain" (log2 selectivity gain, colorbar) or "cell_type" (one color per
+# Cell_Type, legend).
+SPECIFIC_ANALYSES = {
     "sel_vs_kx_loose": dict(
         comparison="sel_vs_kx_loose",
         scan_label="Kx* upper bound 1e-5",
@@ -189,8 +205,11 @@ NEW_ANALYSES = {
     ),
 }
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Data loading
+# ═══════════════════════════════════════════════════════════════════════════════
 
-# ── Load binding-model outputs from each scan ─────────────────────────────────
+
 def load_scan_outputs(scan):
     """Return a DataFrame of successfully optimized pairs for one selectivity scan.
 
@@ -219,7 +238,6 @@ def load_scan_outputs(scan):
 scan_dfs = {scan["label"]: load_scan_outputs(scan) for scan in SCANS}
 
 
-# ── Per-pair selectivity gain (synergy) ───────────────────────────────────────
 def compute_pair_gains(df):
     """Return off-diagonal pairs with an added synergy gain column.
 
@@ -260,28 +278,17 @@ def compute_pair_gains(df):
 pair_dfs = {lbl: compute_pair_gains(df) for lbl, df in scan_dfs.items()}
 
 
-# ── Cross-scan pair identifier ────────────────────────────────────────────────
 def pair_key(df):
     """Stable per-pair key (cell type + sorted receptor pair) for matching across scans."""
     recs = np.sort(df[["Receptor_1", "Receptor_2"]].to_numpy(), axis=1)
     return df["Cell_Type"].to_numpy() + "|" + recs[:, 0] + "|" + recs[:, 1]
 
 
-# ── Comparison shapes: x/y axes, reference lines, limits ──────────────────────
-SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
-GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
-LOG_Y_GAIN_FLOOR = (
-    1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
-)
-KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
-GAIN_YLABEL = r"log$_{2}$ selectivity gain"
-SELECTIVITY_XLABEL = "Binding model selectivity"
-
-# ~276k points per panel in the bulk grid: far denser than the shared point-size constants
-# assume (tuned for scatter plots with far fewer points), so these panels keep their own
-# smaller sizes to stay legible rather than rendering as a solid blob.
-GRID_POINT_SIZE_BG = 3
-GRID_POINT_SIZE_FG = 5
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared scatter-panel helpers — both SPECIFIC_ANALYSES single panels and the scatter grid
+# render one "comparison" (an x/y axis pairing with reference lines and limits) for one scan
+# through the same _draw_comparison_panel, so the two figure families stay in sync.
+# ═══════════════════════════════════════════════════════════════════════════════
 
 
 def _vs_kxstar(ykey):
@@ -404,7 +411,7 @@ COMPARISON_SHAPES = {
         ylim=AFFINITY_BOUNDS,
         kx_vline=True,
     ),
-    # Used only by NEW_ANALYSES single-panel extracts, not the bulk reference grid (see
+    # Used only by SPECIFIC_ANALYSES single-panel extracts, not the bulk reference grid (see
     # GRID_COMPARISON_KEYS): sel_vs_kx_loose fixes the y-axis to SELEC_BOUNDS (rather than
     # auto-scaling) so it matches sel_vs_targ1_aff's y-axis for side-by-side placement.
     "sel_vs_kx_loose": _row(
@@ -426,7 +433,7 @@ COMPARISON_SHAPES = {
 }
 
 # The bulk reference grid (fig-scatter-grid) renders exactly these 8 original comparisons;
-# NEW_ANALYSES entries reference COMPARISON_SHAPES directly and never touch this list.
+# SPECIFIC_ANALYSES entries reference COMPARISON_SHAPES directly and never touch this list.
 GRID_COMPARISON_KEYS = [
     "sel_vs_kx",
     "sig_aff_vs_kx",
@@ -477,8 +484,8 @@ gain_norm = Normalize(vmin=0, vmax=GAIN_COLOR_MAX)
 
 # Cell types actually present across this file's loaded scans, in the project-wide
 # canonical order (see bicytok.figure_styles.CELL_TYPES): every color_by="cell_type"
-# NEW_ANALYSES panel and the standalone fig-celltype-legend cell below look colors up in
-# the shared CELL_TYPE_COLORS, so a given cell type gets the same color here as it does in
+# SPECIFIC_ANALYSES panel and fig-celltype-legend below look colors up in the shared
+# CELL_TYPE_COLORS, so a given cell type gets the same color here as it does in
 # scan_comparison_scatter.qmd and any other all-cell-type analysis, not just within this file.
 ALL_CELL_TYPES = sorted(
     set().union(*(df["Cell_Type"].unique() for df in pair_dfs.values())),
@@ -578,116 +585,9 @@ def _draw_comparison_panel(
     return result
 
 
-def plot_new_analysis(key):
-    """Render one curated single-panel analysis from NEW_ANALYSES as a standalone figure.
-
-    color_by="cell_type" panels omit their legend (see the shared fig-celltype-legend cell
-    instead); color_by="gain" panels get a colorbar, sized via FIGSIZE["square_scatter_
-    with_colorbar"] + COLORBAR_FRACTION/COLORBAR_PAD so the plot area still matches
-    FIGSIZE["square_scatter"] rather than being squeezed narrower by the colorbar.
-    """
-    spec = NEW_ANALYSES[key]
-    comp = COMPARISON_SHAPES[spec["comparison"]]
-    color_by = spec.get("color_by", "gain")
-    scan = next(s for s in SCANS if s["label"] == spec["scan_label"])
-    sd = scan_base_arrays(scan)
-
-    if color_by == "cell_type":
-        aux_vals = pair_dfs[spec["scan_label"]]["Cell_Type"].to_numpy()
-    else:
-        aux_vals = scan_colors_gain[spec["scan_label"]]
-
-    figsize = (
-        FIGSIZE["square_scatter_with_colorbar"]
-        if color_by == "gain"
-        else FIGSIZE["square_scatter"]
-    )
-    fig, ax = plt.subplots(figsize=figsize)
-    result = _draw_comparison_panel(
-        ax,
-        comp,
-        scan,
-        sd,
-        aux_vals,
-        color_by,
-        point_size_bg=POINT_SIZE_XS,
-        point_size_fg=POINT_SIZE_BACKGROUND,
-    )
-    ax.set_xlabel(comp["xlabel"])
-    ax.set_ylabel(comp["ylabel"])
-
-    if spec.get("log_y"):
-        ax.set_yscale("log")
-        ax.set_ylim(bottom=LOG_Y_GAIN_FLOOR)
-
-    if color_by == "gain":
-        fig.colorbar(
-            result,
-            ax=ax,
-            label=r"log$_{2}$ selectivity gain",
-            fraction=COLORBAR_FRACTION,
-            pad=COLORBAR_PAD,
-        )
-
-    set_tick_count(ax, 3, None)
-
-    plt.tight_layout()
-    plt.show()
-```
-
-```{python}
-#| label: fig-sel-vs-kx-loose
-plot_new_analysis("sel_vs_kx_loose")
-```
-
-```{python}
-#| label: fig-sel-vs-targ1aff-loose
-plot_new_analysis("sel_vs_targ1aff_loose")
-```
-
-```{python}
-#| label: fig-gain-vs-sel-loose
-plot_new_analysis("gain_vs_sel_loose")
-```
-
-```{python}
-#| label: fig-gain-vs-sel-loose-log
-plot_new_analysis("gain_vs_sel_loose_log")
-```
-
-```{python}
-#| label: fig-gain-vs-sel-bivalent
-plot_new_analysis("gain_vs_sel_bivalent")
-```
-
-```{python}
-#| label: fig-gain-vs-sel-mixedval
-plot_new_analysis("gain_vs_sel_mixedval")
-```
-
-```{python}
-#| label: fig-celltype-legend
-#| fig-cap: "Shared legend for the cell-type-colored NEW_ANALYSES panels above"
-# Detached legend, mirroring suppfig-scan-outliers-legend: every color_by="cell_type" panel
-# above uses the same CELL_TYPE_COLORS mapping and omits its own legend, so this one legend
-# covers all of them and can be positioned independently (e.g. in Illustrator).
-import matplotlib.lines as mlines
-
-from bicytok.figure_styles import standalone_legend_figure
-
-_celltype_legend_handles = [
-    mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
-    for ct in ALL_CELL_TYPES
-]
-standalone_legend_figure(
-    _celltype_legend_handles, ALL_CELL_TYPES, ncol=2, title="Cell type"
-)
-plt.show()
-```
-
-```{python}
-# ── Shared overlaid-histogram helper ──────────────────────────────────────────
-from bicytok.figure_styles import FONT_SIZE_ANNOT
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared histogram helper
+# ═══════════════════════════════════════════════════════════════════════════════
 
 
 def overlay_hist(
@@ -760,7 +660,82 @@ def overlay_figure(
     plt.show()
 
 
-# ── Precomputed distributions for the four summary figures ────────────────────
+# ═══════════════════════════════════════════════════════════════════════════════
+# Thin figure-generation functions — one per analysis type, in the order they're
+# rendered below: specific single-panel figures, parameter histograms, scatter grid.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def plot_specific_analysis(key):
+    """Render one specific single-panel analysis from SPECIFIC_ANALYSES as a standalone figure.
+
+    color_by="cell_type" panels omit their legend (see the shared fig-celltype-legend cell
+    instead); color_by="gain" panels get a colorbar, sized via FIGSIZE["square_scatter_
+    with_colorbar"] + COLORBAR_FRACTION/COLORBAR_PAD so the plot area still matches
+    FIGSIZE["square_scatter"] rather than being squeezed narrower by the colorbar.
+    """
+    spec = SPECIFIC_ANALYSES[key]
+    comp = COMPARISON_SHAPES[spec["comparison"]]
+    color_by = spec.get("color_by", "gain")
+    scan = next(s for s in SCANS if s["label"] == spec["scan_label"])
+    sd = scan_base_arrays(scan)
+
+    if color_by == "cell_type":
+        aux_vals = pair_dfs[spec["scan_label"]]["Cell_Type"].to_numpy()
+    else:
+        aux_vals = scan_colors_gain[spec["scan_label"]]
+
+    figsize = (
+        FIGSIZE["square_scatter_with_colorbar"]
+        if color_by == "gain"
+        else FIGSIZE["square_scatter"]
+    )
+    fig, ax = plt.subplots(figsize=figsize)
+    result = _draw_comparison_panel(
+        ax,
+        comp,
+        scan,
+        sd,
+        aux_vals,
+        color_by,
+        point_size_bg=POINT_SIZE_XS,
+        point_size_fg=POINT_SIZE_BACKGROUND,
+    )
+    ax.set_xlabel(comp["xlabel"])
+    ax.set_ylabel(comp["ylabel"])
+
+    if spec.get("log_y"):
+        ax.set_yscale("log")
+        ax.set_ylim(bottom=LOG_Y_GAIN_FLOOR)
+
+    if color_by == "gain":
+        fig.colorbar(
+            result,
+            ax=ax,
+            label=r"log$_{2}$ selectivity gain",
+            fraction=COLORBAR_FRACTION,
+            pad=COLORBAR_PAD,
+        )
+
+    set_tick_count(ax, 3, None)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def plot_celltype_legend():
+    """Detached legend shared by every color_by="cell_type" SPECIFIC_ANALYSES panel: each
+    such panel omits its own legend, so this one legend covers all of them and can be
+    positioned independently (e.g. in Illustrator).
+    """
+    handles = [
+        mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
+        for ct in ALL_CELL_TYPES
+    ]
+    standalone_legend_figure(handles, ALL_CELL_TYPES, ncol=2, title="Cell type")
+    plt.show()
+
+
 # Concatenations below draw only from ACTIVE_SCANS labels, so bin ranges aren't stretched by
 # data (e.g. the high-valency scans) that these figures never actually plot.
 _active_labels = [s["label"] for s in ACTIVE_SCANS]
@@ -845,49 +820,6 @@ def plot_gain_dist():
         ref_lines=(0.0,),
         logy=True,
     )
-```
-
-```{python}
-#| label: fig-kxstar-dist
-plot_kxstar_dist()
-```
-
-```{python}
-#| label: fig-affinity-dist
-plot_affinity_dist()
-```
-
-```{python}
-#| label: fig-selectivity-dist
-plot_selectivity_dist()
-```
-
-```{python}
-#| label: fig-gain-dist
-plot_gain_dist()
-```
-
-```{python}
-# ── Bulk reference grid (diagnostic, not a manuscript figure) ─────────────────
-# One grid gathering every per-pair scatter from GRID_COMPARISON_KEYS: rows are comparisons,
-# columns are scans (loose bound left, tight bound right). The first four rows put each output
-# on y vs. optimal log10(Kx*) on x; the last three put log2 selectivity gain on y vs. an output
-# on x. Every panel uses the same coloring: all pairs in gray for context, with pairs that are
-# synergistic in that scan's reference scan (its "gain_ref") overlaid and colored by the
-# reference scan's log2 gain (strongest drawn last). Pointing the tight scan at the loose scan
-# maps the loose-bound gain onto the tight coordinates, so the tight-bound column shows exactly
-# where the once-synergistic pairs are trapped once Kx* is capped — pinned at the wall, driven to
-# the affinity ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales
-# are shared within a row (across scans), not down a column, so x and y labels are set per row.
-
-PANEL_W, PANEL_H = 4.3, 3.0
-
-# This grid packs 8 comparisons x len(SCANS) scans into one figure, so its labels use fixed
-# reduced sizes rather than the shared label/tick constants (which would overrun a 4.3x3.0"
-# panel repeated across many subplots); values match the original tuning for this grid.
-GRID_TITLE_FONTSIZE = 14
-GRID_LABEL_FONTSIZE = 13
-GRID_TICK_FONTSIZE = 10
 
 
 def _sync_row(axes_row):
@@ -902,7 +834,20 @@ def _sync_row(axes_row):
 
 
 def build_comparison_grid():
-    """Draw the full comparison grid (rows = GRID_COMPARISON_KEYS, cols = ACTIVE_SCANS)."""
+    """Draw the full comparison grid (rows = GRID_COMPARISON_KEYS, cols = ACTIVE_SCANS).
+
+    One grid gathering every per-pair scatter from GRID_COMPARISON_KEYS: rows are
+    comparisons, columns are scans (loose bound left, tight bound right). The first four
+    rows put each output on y vs. optimal log10(Kx*) on x; the last three put log2
+    selectivity gain on y vs. an output on x. Every panel uses the same coloring: all pairs
+    in gray for context, with pairs that are synergistic in that scan's reference scan (its
+    "gain_ref") overlaid and colored by the reference scan's log2 gain (strongest drawn
+    last). Pointing the tight scan at the loose scan maps the loose-bound gain onto the
+    tight coordinates, so the tight-bound column shows exactly where the once-synergistic
+    pairs are trapped once Kx* is capped — pinned at the wall, driven to the affinity
+    ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales are
+    shared within a row (across scans), not down a column, so x and y labels are set per row.
+    """
     grid_comps = [COMPARISON_SHAPES[k] for k in GRID_COMPARISON_KEYS]
     fig, axes = plt.subplots(
         len(grid_comps),
@@ -946,358 +891,62 @@ def plot_comparison_grid():
 ```
 
 ```{python}
+#| label: fig-sel-vs-kx-loose
+plot_specific_analysis("sel_vs_kx_loose")
+```
+
+```{python}
+#| label: fig-sel-vs-targ1aff-loose
+plot_specific_analysis("sel_vs_targ1aff_loose")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-loose
+plot_specific_analysis("gain_vs_sel_loose")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-loose-log
+plot_specific_analysis("gain_vs_sel_loose_log")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-bivalent
+plot_specific_analysis("gain_vs_sel_bivalent")
+```
+
+```{python}
+#| label: fig-gain-vs-sel-mixedval
+plot_specific_analysis("gain_vs_sel_mixedval")
+```
+
+```{python}
+#| label: fig-celltype-legend
+#| fig-cap: "Shared legend for the cell-type-colored SPECIFIC_ANALYSES panels above"
+plot_celltype_legend()
+```
+
+```{python}
+#| label: fig-kxstar-dist
+plot_kxstar_dist()
+```
+
+```{python}
+#| label: fig-affinity-dist
+plot_affinity_dist()
+```
+
+```{python}
+#| label: fig-selectivity-dist
+plot_selectivity_dist()
+```
+
+```{python}
+#| label: fig-gain-dist
+plot_gain_dist()
+```
+
+```{python}
 #| label: fig-scatter-grid
 plot_comparison_grid()
-```
-
-```{python}
-# ── Co-pinning flow: how pairs move between constraint categories ──────────────
-# Kx* and target affinity are compensatory avidity sources, so a pair that has maxed both
-# has no headroom left — it is genuinely constrained by the Kx* bound. Each pair is labeled
-# by whether it is pinned at its scan's Kx* upper bound and whether either target arm sits at
-# the affinity ceiling, giving four categories. Pairs are matched across scans (cell type +
-# sorted receptor pair), and the alluvial shows how the loose-bound categories redistribute
-# under the tight bound. Ribbons are colored by source category, so each destination block's
-# composition reveals where its pairs were pulled from.
-
-from matplotlib.patches import Patch, Rectangle
-
-from bicytok.figure_styles import FONT_SIZE_LABEL, standalone_legend_figure
-
-# Shared palette for both flow figures below (see CROSSED_CONDITION_COLORS: reused from
-# scan_outliers.qmd's outlier categories, which have the same neither/A-only/B-only/both
-# shape): index 0 is "neither condition", 3 is "both conditions", 1/2 are each condition
-# alone (see each category-name list for the specific conditions).
-FLOW_CAT_COLORS = CROSSED_CONDITION_COLORS
-COPINNING_CAT_NAMES = [
-    "Both interior",
-    "Aff ceiling only",
-    "Kx* pinned only",
-    "Doubly pinned",
-]
-
-
-def classify_copinning(df, kx_upper):
-    """Label each pair by constraint category and build a cross-scan matching key.
-
-    Category codes: 0 both interior, 1 aff ceiling only, 2 Kx* pinned only, 3 doubly pinned.
-    The key (cell type + sorted receptor pair) identifies the same pair across scans.
-    """
-    kx_pinned = (np.abs(df["Kx_star"] - kx_upper) < PIN_TOL).to_numpy()
-    aff_ceiling = (
-        np.maximum(df["Affinity_Receptor_1"], df["Affinity_Receptor_2"])
-        > AFFINITY_OPT_BOUNDS[1] - AFF_CEIL_EPS
-    ).to_numpy()
-    return pd.DataFrame(
-        {
-            "key": pair_key(df),
-            "cat": 2 * kx_pinned.astype(int) + aff_ceiling.astype(int),
-        }
-    )
-
-
-# Selectivity/gain flow quadrant thresholds below (fig-selgain-flow). SELEC_HIGH_CUTOFF is
-# distinct from SELEC_FLOOR, which marks the ~0.5 no-selectivity floor used elsewhere in this
-# file; this cutoff instead marks pairs selective enough to be manuscript-relevant.
-# GAIN_HIGH_CUTOFF is a log2 gain threshold; 0 (the default) is the synergy line used
-# elsewhere in this file (bispecific beats the better monospecific constituent), but both
-# cutoffs are also exposed as build_selgain_flow/plot_selgain_flow arguments so they can be
-# tuned to isolate a specific population (e.g. pairs only reaching meaningful gain at
-# high valency) without editing these module-level defaults.
-SELEC_HIGH_CUTOFF = 0.91
-GAIN_HIGH_CUTOFF = 0.0
-SEL_GAIN_CAT_NAMES = [
-    "Low selectivity, gain-",
-    "Low selectivity, gain+",
-    "High selectivity, gain-",
-    "High selectivity, gain+",
-]
-
-
-def classify_selectivity_gain(df, selec_cutoff, gain_cutoff):
-    """Label each pair by selectivity/gain quadrant and build a cross-scan matching key.
-
-    Category codes: 0 low selectivity & gain <= gain_cutoff, 1 low selectivity &
-    gain > gain_cutoff, 2 high selectivity & gain <= gain_cutoff, 3 high selectivity &
-    gain > gain_cutoff.
-    """
-    high_sel = (df["Selectivity"] >= selec_cutoff).to_numpy()
-    high_gain = (df["log2_gain"] > gain_cutoff).to_numpy()
-    return pd.DataFrame(
-        {
-            "key": pair_key(df),
-            "cat": 2 * high_sel.astype(int) + high_gain.astype(int),
-        }
-    )
-
-
-def draw_category_flow(ax, trans, colors, gap=0.015, bar_w=0.03, vertical=False):
-    """Alluvial flow between two scans' category assignments.
-
-    Source-scan and destination-scan blocks sit at opposite ends of the flow axis, sized
-    proportional to pair counts; ribbons connect them, colored by source category so each
-    destination block's composition shows where its pairs came from. By default the flow
-    axis is x (source left, destination right, flowing left-to-right) and blocks are stacked
-    along y; vertical=True swaps these (source top, destination bottom, flowing top-to-bottom,
-    blocks laid out along x) for a wide/short footprint, e.g. a poster panel.
-    """
-    total = trans.sum()
-    n_cat = trans.shape[0]
-    size_a, size_b = trans.sum(axis=1), trans.sum(axis=0)
-    usable = 1 - gap * (n_cat - 1)
-
-    def block_edges(sizes):
-        edges, top = [], 1.0
-        for s in sizes:
-            height = s / total * usable
-            edges.append((top, top - height))
-            top -= height + gap
-        return edges
-
-    edges_a, edges_b = block_edges(size_a), block_edges(size_b)
-
-    if vertical:
-        for edges, y0 in [(edges_a, 1.0), (edges_b, -bar_w)]:
-            for cat, (top, bot) in enumerate(edges):
-                ax.add_patch(
-                    Rectangle(
-                        (bot, y0),
-                        top - bot,
-                        bar_w,
-                        color=colors[cat],
-                        ec="white",
-                        lw=0.5,
-                        zorder=3,
-                    )
-                )
-    else:
-        for edges, x0 in [(edges_a, -bar_w), (edges_b, 1.0)]:
-            for cat, (top, bot) in enumerate(edges):
-                ax.add_patch(
-                    Rectangle(
-                        (x0, bot),
-                        bar_w,
-                        top - bot,
-                        color=colors[cat],
-                        ec="white",
-                        lw=0.5,
-                        zorder=3,
-                    )
-                )
-
-    cursor_a = [top for top, _ in edges_a]
-    cursor_b = [top for top, _ in edges_b]
-    xs = np.linspace(0, 1, 60)
-    ease = (1 - np.cos(np.pi * xs)) / 2
-    flow_axis = 1 - xs if vertical else xs  # vertical flows top (1) to bottom (0)
-    for a in range(n_cat):
-        for b in range(n_cat):
-            if trans[a, b] == 0:
-                continue
-            height = trans[a, b] / total * usable
-            l_top, l_bot = cursor_a[a], cursor_a[a] - height
-            r_top, r_bot = cursor_b[b], cursor_b[b] - height
-            cursor_a[a], cursor_b[b] = l_bot, r_bot
-            lower = l_bot + (r_bot - l_bot) * ease
-            upper = l_top + (r_top - l_top) * ease
-            fill = ax.fill_betweenx if vertical else ax.fill_between
-            fill(flow_axis, lower, upper, color=colors[a], alpha=0.45, lw=0, zorder=1)
-
-    if vertical:
-        label_spots = [
-            (edges_a, 1.0 + bar_w + 0.015, "bottom"),
-            (edges_b, -bar_w - 0.015, "top"),
-        ]
-    else:
-        label_spots = [
-            (edges_a, -bar_w - 0.015, "right"),
-            (edges_b, 1.0 + bar_w + 0.015, "left"),
-        ]
-    for edges, off, align in label_spots:
-        sizes = size_a if edges is edges_a else size_b
-        for cat, (top, bot) in enumerate(edges):
-            if sizes[cat] / total <= 0.01:
-                continue
-            center = (top + bot) / 2
-            pos, kwargs = (
-                ((center, off), {"ha": "center", "va": align})
-                if vertical
-                else ((off, center), {"ha": align, "va": "center"})
-            )
-            ax.text(
-                *pos,
-                f"{sizes[cat] / total * 100:.0f}%",
-                fontsize=FONT_SIZE_ANNOT,
-                **kwargs,
-            )
-
-    if vertical:
-        ax.set_xlim(-0.02, 1.09)
-        ax.set_ylim(-0.34, 1.34)
-    else:
-        ax.set_xlim(-0.22, 1.22)
-        ax.set_ylim(-0.02, 1.09)
-    ax.axis("off")
-
-
-def transition_from_matched(matched, n_cat):
-    """Category transition matrix from an already cats_a/cats_b-merged pair table."""
-    cats = range(n_cat)
-    return (
-        pd.crosstab(matched["cat_a"], matched["cat_b"])
-        .reindex(index=cats, columns=cats, fill_value=0)
-        .to_numpy()
-    )
-
-
-def pairs_to_transition(cats_a, cats_b, n_cat):
-    """Cross-scan category transition matrix from two classified pair tables (key, cat)."""
-    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
-    return transition_from_matched(matched, n_cat)
-
-
-def build_copinning_flow(scan_a, scan_b):
-    """Compute the co-pinning category transition matrix between two scans."""
-    cats_a = classify_copinning(pair_dfs[scan_a["label"]], scan_a["kx_upper"])
-    cats_b = classify_copinning(pair_dfs[scan_b["label"]], scan_b["kx_upper"])
-    return pairs_to_transition(cats_a, cats_b, len(COPINNING_CAT_NAMES))
-
-
-def build_selgain_flow(
-    scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only=False
-):
-    """Compute the selectivity/gain quadrant transition matrix between two scans.
-
-    gain_positive_only restricts to pairs classified gain+ (categories 1 or 3, i.e.
-    cat % 2 == 1) in scan_a or scan_b. The gain+ population is a small fraction of all
-    pairs, so without this the transition percentages are dominated by gain- pairs sitting
-    still; restricting to "ever gain+" pairs makes the gain+ population's own selectivity
-    movement legible instead of being diluted by the much larger gain- bulk.
-    """
-    cats_a = classify_selectivity_gain(
-        pair_dfs[scan_a["label"]], selec_cutoff, gain_cutoff
-    )
-    cats_b = classify_selectivity_gain(
-        pair_dfs[scan_b["label"]], selec_cutoff, gain_cutoff
-    )
-    matched = cats_a.merge(cats_b, on="key", suffixes=("_a", "_b"))
-    if gain_positive_only:
-        matched = matched[(matched["cat_a"] % 2 == 1) | (matched["cat_b"] % 2 == 1)]
-    return transition_from_matched(matched, len(SEL_GAIN_CAT_NAMES))
-
-
-def plot_flow(trans, label_a, label_b, vertical=False):
-    """Draw a category-transition alluvial from label_a to label_b as a standalone figure.
-
-    Shared renderer for fig-copinning and fig-selgain-flow: trans carries the figure-specific
-    data, so this function only knows about the generic category flow, not what a category
-    represents. The legend is detached (see flow_legend_figure), so ribbon colors alone would
-    be ambiguous without it. vertical=True draws source-top/destination-bottom instead of the
-    default source-left/destination-right (see draw_category_flow), for a wide/short footprint.
-    """
-    figsize = FIGSIZE["alluvial_flow_vertical" if vertical else "alluvial_flow"]
-    fig, ax = plt.subplots(figsize=figsize)
-    draw_category_flow(ax, trans, FLOW_CAT_COLORS, vertical=vertical)
-    if vertical:
-        ax.text(0.5, 1.19, label_a, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
-        ax.text(0.5, -0.19, label_b, ha="center", va="top", fontsize=FONT_SIZE_LABEL)
-    else:
-        ax.text(0, 1.07, label_a, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
-        ax.text(1, 1.07, label_b, ha="center", va="bottom", fontsize=FONT_SIZE_LABEL)
-    plt.tight_layout()
-    plt.show()
-
-
-def flow_legend_figure(cat_names):
-    """Standalone legend mapping FLOW_CAT_COLORS to cat_names, detached per fig-celltype-legend
-    so it can be positioned independently (e.g. in Illustrator) rather than crowding plot_flow.
-    """
-    handles = [Patch(facecolor=FLOW_CAT_COLORS[i]) for i in range(len(cat_names))]
-    return standalone_legend_figure(handles, cat_names, ncol=len(cat_names))
-
-
-def plot_copinning(scan_a, scan_b):
-    """Draw the co-pinning alluvial flow from scan_a to scan_b as a standalone figure."""
-    trans = build_copinning_flow(scan_a, scan_b)
-    plot_flow(trans, scan_a["label"], scan_b["label"])
-
-
-def plot_selgain_flow(
-    scan_a,
-    scan_b,
-    selec_cutoff=SELEC_HIGH_CUTOFF,
-    gain_cutoff=GAIN_HIGH_CUTOFF,
-    gain_positive_only=False,
-    vertical=False,
-):
-    """Draw the selectivity/gain quadrant alluvial flow from scan_a to scan_b."""
-    trans = build_selgain_flow(
-        scan_a, scan_b, selec_cutoff, gain_cutoff, gain_positive_only
-    )
-    plot_flow(trans, scan_a["label"], scan_b["label"], vertical=vertical)
-```
-
-```{python}
-#| label: fig-copinning
-# Flow from the first (loosest) to the second (tightest) active scan.
-plot_copinning(ACTIVE_SCANS[0], ACTIVE_SCANS[1])
-```
-
-```{python}
-#| label: fig-copinning-legend
-#| fig-cap: "Shared legend for fig-copinning's constraint categories"
-flow_legend_figure(COPINNING_CAT_NAMES)
-plt.show()
-```
-
-```{python}
-#| label: fig-selgain-flow
-# Flow from the monovalent to the bivalent scan.
-plot_selgain_flow(
-    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
-    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
-    gain_positive_only=False,
-)
-```
-
-```{python}
-#| label: fig-selgain-pos-flow
-# Flow from the monovalent to the bivalent scan.
-plot_selgain_flow(
-    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
-    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
-    gain_positive_only=True,
-    gain_cutoff=0.01,
-)
-```
-
-```{python}
-#| label: fig-selgain-flow-legend
-#| fig-cap: "Shared legend for fig-selgain-flow's selectivity/gain quadrants"
-flow_legend_figure(SEL_GAIN_CAT_NAMES)
-plt.show()
-```
-
-```{python}
-#| label: fig-selgain-flow-poster
-# Same as fig-selgain-flow, rotated (source top / destination bottom, ribbons flowing
-# vertically) for a wide/short poster slot.
-plot_selgain_flow(
-    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
-    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
-    gain_positive_only=False,
-    vertical=True,
-)
-```
-
-```{python}
-#| label: fig-selgain-pos-flow-poster
-# Same as fig-selgain-pos-flow, rotated for a wide/short poster slot.
-plot_selgain_flow(
-    next(s for s in SCANS if s["label"] == "Kx* upper bound 1e-5"),
-    next(s for s in SCANS if s["label"] == "Bivalent Kx* upper bound 1e-5"),
-    gain_positive_only=True,
-    gain_cutoff=0.01,
-    vertical=True,
-)
 ```

--- a/figures/scanning_analyses/scan_marker_overlap.qmd
+++ b/figures/scanning_analyses/scan_marker_overlap.qmd
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 
 from bicytok.imports import import_annotation_markers
-from figures.scanning_analyses.scan_runners import (
+from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )

--- a/figures/scanning_analyses/scan_model_params.qmd
+++ b/figures/scanning_analyses/scan_model_params.qmd
@@ -60,7 +60,7 @@ from bicytok.figure_styles import (
 
 apply_style()
 
-## Paremeters
+## Parameters
 
 # Each scan's "gain_ref" names the scan (by label) whose per-pair gain colors this scan's points
 # in fig-scatter-grid: its own label uses its own gain; another scan's label maps that scan's gain
@@ -101,8 +101,8 @@ SCANS = [
 ]
 
 # Scans analyzed by the parameter histograms and fig-scatter-grid. SCANS may hold other
-# scans (e.g. the high-valency ones above), loaded and available to SPECIFIC_ANALYSES by
-# scan_label but excluded from these figures.
+# scans loaded and available to SPECIFIC_ANALYSES by scan_label but excluded
+# from these figures.
 ACTIVE_SCAN_LABELS = [
     "Kx* upper bound 1e-5",
     "Kx* upper bound 1e-9",

--- a/figures/scanning_analyses/scan_model_params.qmd
+++ b/figures/scanning_analyses/scan_model_params.qmd
@@ -7,34 +7,31 @@ Examines how optimal binding-model parameters — Kx*, the three monomer affinit
 
 Three complementary analyses appear below, in this order:
 
-1. **Specific single-panel figures** (`SPECIFIC_ANALYSES`): each entry picks one pre-built comparison shape (an x/y axis pairing with its reference lines and limits, `COMPARISON_SHAPES`), one scan to draw from, and whether points are colored by log2 selectivity gain or by cell type. `plot_specific_analysis(key)` renders one entry as a standalone figure. The most flexible of the three — any scan in `SCANS` can be plotted against any shape.
-2. **Parameter histograms**: four panels aggregating every binding-model output (and the derived gain) over all successfully optimized pairs, across the two `ACTIVE_SCANS`, showing how each distribution's overall shape (rather than per-pair relationships) responds to the Kx* bound:
-   1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked. When a large fraction of pairs optimize to Kx* above the tighter bound, that bound pins them at the wall, compressing the high-Kx* population and plausibly suppressing synergy.
-   2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor (signal, target 1, target 2). Diagonal (rec == rec) pairs are excluded here because the second target receptor is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
+1. **Specific single-panel figures** (`SPECIFIC_ANALYSES`): each entry picks one pre-built comparison shape (an x/y axis pairing with its reference lines and limits, (`COMPARISON_SHAPES`), one scan to draw from, and whether points are colored by log2 selectivity gain or by cell type. The most flexible of the three — any scan in `SCANS` can be plotted against any shape.
+2. **Parameter histograms**: four panels aggregating every binding-model output (and the derived gain) over all successfully optimized pairs, across `ACTIVE_SCANS`, showing how each distribution's overall shape responds to the Kx* bound:
+   1. **Kx\* distribution** — optimal log10(Kx*), with each scan's upper bound marked.
+   2. **Affinity distributions** — optimal monomer affinities, one subpanel per receptor. Diagonal (rec == rec) pairs are excluded: the second target receptor there is modeled with valency 0, leaving its affinity at its initialization value rather than an optimized one.
    3. **Selectivity distribution** — optimal selectivity, targ / (targ + off-targ), on a log density axis to reveal the high-selectivity tail above the ~0.5 no-selectivity floor.
-   4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy (the pair beats either receptor alone). The signal receptor is excluded here, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
-3. **Scatter grid** (`fig-scatter-grid`, reference/diagnostic): a consolidated grid gathering every per-pair scatter, rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last three plot log2 selectivity gain against pair selectivity and against receptor affinity (signal, and pooled target arms). Every panel shares one coloring scheme — all pairs in gray, with pairs that are synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped: pinned at the wall, driven to the affinity ceiling, and with their gain collapsed to ~0. Points are rasterized (~276k per panel). This grid is kept as a diagnostic reference; it does not include the `SPECIFIC_ANALYSES` comparisons above.
+   4. **Selectivity gain distribution** — per pair, bispecific selectivity divided by the larger of its two constituents' monospecific (diagonal) selectivities, as log2 gain on a log density axis. gain > 1 marks synergy. The signal receptor is excluded, since a pair containing the artificial readout receptor is not a genuine two-target combination. Diagonal monospecific entries model a single receptor carrying the combined target valency, so the comparison holds total target valency fixed: gain < 1 means concentrating valency on the better single receptor beats splitting it across two.
+3. **Scatter grid** (`fig-scatter-grid`, reference/diagnostic): a grid gathering every per-pair scatter in `GRID_COMPARISON_KEYS` — rows are comparisons, columns are scans (loose bound left, tight bound right). The first four rows plot each output (selectivity, the three affinities) against optimal log10(Kx*); the last four plot log2 selectivity gain against selectivity, then each receptor's affinity against selectivity. Every panel shares one coloring scheme — all pairs in gray, with pairs synergistic in that scan's chosen reference scan (set per scan via `gain_ref`) overlaid and colored by the reference scan's log2 gain. Pointing the tight scan at the loose scan maps the loose-bound gain onto the tight coordinates by pair key, so the tight-bound column shows exactly where the once-synergistic pairs are trapped when Kx* is capped. Points are rasterized (~276k per panel). This grid does not include the `SPECIFIC_ANALYSES` comparisons above.
 
 # Inputs
-All user-facing parameters are collected at the top of the code cell below, ahead of the data loading and plotting mechanics.
-
-- `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan (Kx* and affinities are not produced by KL/EMD scans) with a matching `.yaml` in the same directory.
-- `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` (by label) analyzed by `fig-kxstar-dist`, `fig-affinity-dist`, `fig-selectivity-dist`, `fig-gain-dist`, and `fig-scatter-grid`. `SPECIFIC_ANALYSES` is not restricted to this subset — any scan in `SCANS` can be referenced by `scan_label`.
-- `SPECIFIC_ANALYSES`: dict of specific single-panel figures. Each entry has a `comparison` (a key into `COMPARISON_SHAPES`), a `scan_label` (any scan in `SCANS`), and a `color_by` of `"gain"` (log2 selectivity gain, colorbar, sized via `FIGSIZE["square_scatter_with_colorbar"]`) or `"cell_type"` (shared `CELL_TYPE_COLORS` mapping; legend omitted per panel, see `fig-celltype-legend`).
+- `SCANS`: list of selectivity scans, each with a CSV `path`, a display `label`, the `kx_upper` optimization bound in log10(M) (or `None` to omit its marker), a plot `color`, and a `gain_ref` naming the scan (by `label`) whose per-pair gain colors this scan's points — its own `label` to use its own gain, or another scan's to map that scan's gain onto these coordinates. Each CSV must be a selectivity scan with a matching `.yaml`.
+- `ACTIVE_SCAN_LABELS` / `ACTIVE_SCANS`: the subset of `SCANS` analyzed by the parameter histograms and `fig-scatter-grid`. `SPECIFIC_ANALYSES` is not restricted to this subset.
+- `SPECIFIC_ANALYSES`: dict of specific single-panel figures. Each entry has a `comparison` (a key into `COMPARISON_SHAPES`), a `scan_label` (any scan in `SCANS`), and a `color_by` of `"gain"` (log2 selectivity gain, colorbar) or `"cell_type"` (shared `CELL_TYPE_COLORS`, legend omitted per panel — see `fig-celltype-legend`).
 - `AFFINITY_BOUNDS` / `SELEC_BOUNDS`: shared (min, max) display ranges in log10(M) / fraction, drawn as reference lines or axis limits across the affinity and selectivity panels.
 
 # Outputs
-- **`fig-sel-vs-kx-loose`**: Selectivity vs. optimal log10(Kx*), 1e-5 bound scan, colored by cell type. Shares its y-axis range (`SELEC_BOUNDS`) with `fig-sel-vs-targ1aff-loose` for side-by-side manuscript placement.
+- **`fig-sel-vs-kx-loose`**: Selectivity vs. optimal log10(Kx*), 1e-5 bound scan, colored by cell type. Shares its y-axis range (`SELEC_BOUNDS`) with `fig-sel-vs-targ1aff-loose`.
 - **`fig-sel-vs-targ1aff-loose`**: Selectivity vs. Target 1 affinity, 1e-5 bound scan, colored by cell type.
-- **`fig-gain-vs-sel-loose`**: log2 selectivity gain vs. Selectivity, 1e-5 bound scan.
-- **`fig-gain-vs-sel-bivalent`**: log2 selectivity gain vs. Selectivity, bivalent high-valency scan (in `SCANS` but outside `ACTIVE_SCAN_LABELS`; colored by its own gain via its self-referencing `gain_ref`).
-- **`fig-gain-vs-sel-mixedval`**: log2 selectivity gain vs. Selectivity, mixed-valency scan (in `SCANS` but outside `ACTIVE_SCAN_LABELS`; colored by its own gain).
-- **`fig-celltype-legend`**: shared legend mapping cell type to color for every `color_by="cell_type"` panel above, detached so it can be positioned independently (e.g. in Illustrator) rather than repeated per panel.
-- **`fig-kxstar-dist`**: overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked and the fraction of pairs pinned at that bound annotated
-- **`fig-affinity-dist`**: overlaid density histograms of optimal affinity, one subpanel per receptor (signal, target 1, target 2); diagonal pairs excluded
-- **`fig-selectivity-dist`**: overlaid log-density histograms of optimal selectivity
-- **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain (bispecific / max constituent monospecific); gain > 1 is synergy
-- **`fig-scatter-grid`** (reference/diagnostic): rasterized scatter grid consolidating every per-pair comparison (rows) across scans (columns) — each output vs. optimal log10(Kx*), and log2 gain vs. selectivity and affinity — with each scan's panels colored by the gain of its `gain_ref` scan, so pointing the tight scan at the loose one shows where synergistic pairs are trapped
+- **`fig-gain-vs-sel-loose`** / **`fig-gain-vs-sel-loose-log`**: log2 selectivity gain vs. selectivity, 1e-5 bound scan, linear and log y-axis.
+- **`fig-gain-vs-sel-bivalent`** / **`fig-gain-vs-sel-mixedval`**: log2 selectivity gain vs. selectivity, bivalent / mixed-valency scans (outside `ACTIVE_SCAN_LABELS`; each colored by its own gain via its self-referencing `gain_ref`).
+- **`fig-celltype-legend`**: shared legend for every `color_by="cell_type"` panel above, detached so it can be positioned independently (e.g. in Illustrator).
+- **`fig-kxstar-dist`**: overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked and the fraction of pairs pinned at that bound annotated.
+- **`fig-affinity-dist`**: overlaid density histograms of optimal affinity, one subpanel per receptor; diagonal pairs excluded.
+- **`fig-selectivity-dist`**: overlaid log-density histograms of optimal selectivity.
+- **`fig-gain-dist`**: overlaid log-density histogram of per-pair log2 selectivity gain.
+- **`fig-scatter-grid`** (reference/diagnostic): rasterized scatter grid consolidating every per-pair comparison in `GRID_COMPARISON_KEYS` across scans, colored by each scan's `gain_ref` gain.
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
@@ -63,15 +60,11 @@ from bicytok.figure_styles import (
 
 apply_style()
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Parameters — everything below this line and above "Data loading" is meant to be
-# edited to retarget this file at new scans, thresholds, or display ranges.
-# ═══════════════════════════════════════════════════════════════════════════════
+## Paremeters
 
 # Each scan's "gain_ref" names the scan (by label) whose per-pair gain colors this scan's points
 # in fig-scatter-grid: its own label uses its own gain; another scan's label maps that scan's gain
-# onto these coordinates (pointing the tight scan at the loose scan reveals where pairs get
-# trapped once Kx* is capped).
+# onto these coordinates
 SCANS = [
     # Loose Kx* bound scan
     {
@@ -107,9 +100,9 @@ SCANS = [
     },
 ]
 
-# Scans analyzed by fig-kxstar-dist, fig-affinity-dist, fig-selectivity-dist, fig-gain-dist,
-# and fig-scatter-grid. SCANS may hold other scans (e.g. the high-valency ones above) that are
-# loaded and available to SPECIFIC_ANALYSES by scan_label but excluded from these figures.
+# Scans analyzed by the parameter histograms and fig-scatter-grid. SCANS may hold other
+# scans (e.g. the high-valency ones above), loaded and available to SPECIFIC_ANALYSES by
+# scan_label but excluded from these figures.
 ACTIVE_SCAN_LABELS = [
     "Kx* upper bound 1e-5",
     "Kx* upper bound 1e-9",
@@ -123,12 +116,15 @@ ACTIVE_SCANS = [s for s in SCANS if s["label"] in ACTIVE_SCAN_LABELS]
 AFFINITY_BOUNDS = (5.9, 12.1)
 SELEC_BOUNDS = (0.47, 1.02)
 
-# Affinity CSV columns mapped to their receptor role (order = subpanel order).
-AFF_COLS = {
-    "Affinity_Receptor_0": "Signal receptor",
-    "Affinity_Receptor_1": "Target receptor 1",
-    "Affinity_Receptor_2": "Target receptor 2",
-}
+# One entry per receptor role: the CSV affinity column, its key in scan_base_arrays(), the
+# COMPARISON_SHAPES key prefix, and its display title. Order = affinity-histogram subpanel
+# order and COMPARISON_SHAPES row order.
+RECEPTORS = [
+    dict(csv_col="Affinity_Receptor_0", sd_key="aff0", shape_prefix="sig_aff", title="Signal receptor"),
+    dict(csv_col="Affinity_Receptor_1", sd_key="aff1", shape_prefix="targ1_aff", title="Target receptor 1"),
+    dict(csv_col="Affinity_Receptor_2", sd_key="aff2", shape_prefix="targ2_aff", title="Target receptor 2"),
+]
+AFF_COLS = {r["csv_col"]: r["title"] for r in RECEPTORS}
 
 # Signal (readout) receptor name, excluded from the pair-level gain metric because a pair
 # containing the artificial signal receptor is not a genuine two-target combination.
@@ -139,25 +135,17 @@ PIN_TOL = 1e-2
 
 RASTERIZE = True
 
-# Scatter-panel display tuning, shared by SPECIFIC_ANALYSES and the scatter grid.
+# Scatter-panel display tuning, shared by SPECIFIC_ANALYSES and the scatter grid
 SELEC_FLOOR = 0.505  # pair selectivity at/below this is effectively no selectivity
 GAIN_COLOR_MAX = 0.15  # log2 gain at which the synergy color saturates
-LOG_Y_GAIN_FLOOR = (
-    1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
-)
+LOG_Y_GAIN_FLOOR = 1e-5  # y-axis lower limit for log_y panels, clipping trailing near-zero-gain points
 KX_XLABEL = r"Optimal log$_{10}$(K$_{x}$*)"
 GAIN_YLABEL = r"log$_{2}$ selectivity gain"
 SELECTIVITY_XLABEL = "Binding model selectivity"
 
-# ~276k points per panel in the bulk grid: far denser than the shared point-size constants
-# assume (tuned for scatter plots with far fewer points), so these panels keep their own
-# smaller sizes to stay legible rather than rendering as a solid blob.
+# Figure parameters for non-specific scatter panels
 GRID_POINT_SIZE_BG = 3
 GRID_POINT_SIZE_FG = 5
-
-# Scatter grid layout. This grid packs 8 comparisons x len(SCANS) scans into one figure, so
-# its labels use fixed reduced sizes rather than the shared label/tick constants (which would
-# overrun a 4.3x3.0" panel repeated across many subplots).
 PANEL_W, PANEL_H = 4.3, 3.0
 GRID_TITLE_FONTSIZE = 14
 GRID_LABEL_FONTSIZE = 13
@@ -205,17 +193,11 @@ SPECIFIC_ANALYSES = {
     ),
 }
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Data loading
-# ═══════════════════════════════════════════════════════════════════════════════
+# ── Data loading ────────────────────────────────────────────────────────────────────
 
 
 def load_scan_outputs(scan):
-    """Return a DataFrame of successfully optimized pairs for one selectivity scan.
-
-    Rows with NaN outputs (uncomputed upper triangle, failed optimizations) are
-    dropped; these are NaN across all output columns simultaneously.
-    """
+    """Successfully optimized pairs for one selectivity scan (NaN-output rows dropped)."""
     yaml_path = os.path.splitext(scan["path"])[0] + ".yaml"
     assert os.path.exists(yaml_path), f"YAML not found at {yaml_path}"
     with open(yaml_path) as f:
@@ -224,14 +206,7 @@ def load_scan_outputs(scan):
             "optimized there."
         )
 
-    cols = [
-        "Cell_Type",
-        "Receptor_1",
-        "Receptor_2",
-        "Selectivity",
-        "Kx_star",
-        *AFF_COLS,
-    ]
+    cols = ["Cell_Type", "Receptor_1", "Receptor_2", "Selectivity", "Kx_star", *AFF_COLS]
     return pd.read_csv(scan["path"], usecols=cols).dropna(subset=["Selectivity"])
 
 
@@ -239,17 +214,13 @@ scan_dfs = {scan["label"]: load_scan_outputs(scan) for scan in SCANS}
 
 
 def compute_pair_gains(df):
-    """Return off-diagonal pairs with an added synergy gain column.
+    """Off-diagonal pairs (signal receptor excluded) with an added synergy gain column.
 
     gain = bispecific selectivity / max(constituent monospecific selectivities), where the
-    monospecific values are the diagonal (rec == rec) entries. The artificial signal
-    receptor is excluded from pair membership. Rows retain all binding-model outputs so the
-    returned table also serves the per-pair metric comparisons downstream.
-
-    Diagonal (mono) entries model a single receptor carrying the combined target valency,
-    while off-diagonal pairs split that valency one arm per receptor, so the comparison
-    holds total target valency fixed. gain < 1 (the common case) means concentrating
-    valency on the better single receptor beats splitting it across two.
+    monospecific values are the diagonal (rec == rec) entries. Diagonal entries model a
+    single receptor carrying the combined target valency, so this holds total target
+    valency fixed: gain < 1 (the common case) means concentrating valency on the better
+    single receptor beats splitting it across two.
     """
     mono_map = df[df["Receptor_1"] == df["Receptor_2"]].set_index(
         ["Cell_Type", "Receptor_1"]
@@ -284,52 +255,16 @@ def pair_key(df):
     return df["Cell_Type"].to_numpy() + "|" + recs[:, 0] + "|" + recs[:, 1]
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Shared scatter-panel helpers — both SPECIFIC_ANALYSES single panels and the scatter grid
+# ── Shared scatter-panel helpers — both SPECIFIC_ANALYSES single panels and the scatter grid
 # render one "comparison" (an x/y axis pairing with reference lines and limits) for one scan
-# through the same _draw_comparison_panel, so the two figure families stay in sync.
-# ═══════════════════════════════════════════════════════════════════════════════
+# through the same _draw_comparison_panel, so the two figure families stay in sync. ────────
 
 
-def _vs_kxstar(ykey):
-    """Comparison getter: an output on y against optimal log10(Kx*) on x."""
-
-    def get(sd, cvals):
-        return sd["kx"], sd[ykey], cvals
-
-    return get
-
-
-def _gain_vs(xkey):
-    """Comparison getter: log2 gain on y against an output on x.
-
-    The pooled target-affinity comparison stacks both target arms, tiling y and the color
-    values to match the doubled x.
-    """
+def _axes(xkey, ykey):
+    """Comparison getter: sd[xkey] on x, sd[ykey] on y (sd = scan_base_arrays(scan))."""
 
     def get(sd, cvals):
-        if xkey == "targ_aff":
-            x = np.concatenate([sd["aff1"], sd["aff2"]])
-            return x, np.tile(sd["log2_gain"], 2), np.concatenate([cvals, cvals])
-        return sd[xkey], sd["log2_gain"], cvals
-
-    return get
-
-
-def _vs_selectivity(ykey):
-    """Comparison getter: an output on y against selectivity on x."""
-
-    def get(sd, cvals):
-        return sd["sel"], sd[ykey], cvals
-
-    return get
-
-
-def _sel_vs(xkey):
-    """Comparison getter: selectivity on y against an output on x."""
-
-    def get(sd, cvals):
-        return sd[xkey], sd["sel"], cvals
+        return sd[xkey], sd[ykey], cvals
 
     return get
 
@@ -354,85 +289,47 @@ def _row(
 
 COMPARISON_SHAPES = {
     "sel_vs_kx": _row(
-        _vs_kxstar("sel"), KX_XLABEL, SELECTIVITY_XLABEL, yrefs=(0.5,), kx_vline=True
-    ),
-    "sig_aff_vs_kx": _row(
-        _vs_kxstar("aff0"),
-        KX_XLABEL,
-        r"Signal receptor K$_{a}$ (log$_{10}$(M))",
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
-    ),
-    "targ1_aff_vs_kx": _row(
-        _vs_kxstar("aff1"),
-        KX_XLABEL,
-        r"Target receptor 1 K$_{a}$ (log$_{10}$(M))",
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
-    ),
-    "targ2_aff_vs_kx": _row(
-        _vs_kxstar("aff2"),
-        KX_XLABEL,
-        r"Target receptor 2 K$_{a}$ (log$_{10}$(M))",
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
+        _axes("kx", "sel"), KX_XLABEL, SELECTIVITY_XLABEL, yrefs=(0.5,), kx_vline=True
     ),
     "gain_vs_sel": _row(
-        _gain_vs("sel"),
+        _axes("sel", "log2_gain"),
         SELECTIVITY_XLABEL,
         GAIN_YLABEL,
         xrefs=(SELEC_FLOOR,),
         yrefs=(0.0,),
     ),
-    "sig_aff_vs_sel": _row(
-        _vs_selectivity("aff0"),
-        SELECTIVITY_XLABEL,
-        r"Signal receptor K$_{a}$ (log$_{10}$(M))",
-        xrefs=(SELEC_FLOOR,),
-        xlim=SELEC_BOUNDS,
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
-    ),
-    "targ1_aff_vs_sel": _row(
-        _vs_selectivity("aff1"),
-        SELECTIVITY_XLABEL,
-        r"Target receptor 1 K$_{a}$ (log$_{10}$(M))",
-        xrefs=(SELEC_FLOOR,),
-        xlim=SELEC_BOUNDS,
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
-    ),
-    "targ2_aff_vs_sel": _row(
-        _vs_selectivity("aff2"),
-        SELECTIVITY_XLABEL,
-        r"Target receptor 2 K$_{a}$ (log$_{10}$(M))",
-        xrefs=(SELEC_FLOOR,),
-        xlim=SELEC_BOUNDS,
-        ylim=AFFINITY_BOUNDS,
-        kx_vline=True,
-    ),
-    # Used only by SPECIFIC_ANALYSES single-panel extracts, not the bulk reference grid (see
-    # GRID_COMPARISON_KEYS): sel_vs_kx_loose fixes the y-axis to SELEC_BOUNDS (rather than
-    # auto-scaling) so it matches sel_vs_targ1_aff's y-axis for side-by-side placement.
-    "sel_vs_kx_loose": _row(
-        _vs_kxstar("sel"),
-        KX_XLABEL,
-        SELECTIVITY_XLABEL,
-        ylim=SELEC_BOUNDS,
-        yrefs=(0.5,),
-        kx_vline=True,
-    ),
-    "sel_vs_targ1_aff": _row(
-        _sel_vs("aff1"),
-        r"Target receptor K$_{a}$ (log$_{10}$(M))",
-        SELECTIVITY_XLABEL,
-        xlim=AFFINITY_BOUNDS,
-        ylim=SELEC_BOUNDS,
-        yrefs=(0.5,),
-    ),
 }
 
-# The bulk reference grid (fig-scatter-grid) renders exactly these 8 original comparisons;
+# One "<prefix>_vs_kx" and one "<prefix>_vs_sel" comparison per receptor in RECEPTORS.
+for _r in RECEPTORS:
+    _ylabel = rf"{_r['title']} K$_{{a}}$ (log$_{{10}}$(M))"
+    COMPARISON_SHAPES[f"{_r['shape_prefix']}_vs_kx"] = _row(
+        _axes("kx", _r["sd_key"]), KX_XLABEL, _ylabel, ylim=AFFINITY_BOUNDS, kx_vline=True
+    )
+    COMPARISON_SHAPES[f"{_r['shape_prefix']}_vs_sel"] = _row(
+        _axes("sel", _r["sd_key"]),
+        SELECTIVITY_XLABEL,
+        _ylabel,
+        xrefs=(SELEC_FLOOR,),
+        xlim=SELEC_BOUNDS,
+        ylim=AFFINITY_BOUNDS,
+        kx_vline=True,
+    )
+
+# Used only by SPECIFIC_ANALYSES single-panel extracts, not the bulk reference grid (see
+# GRID_COMPARISON_KEYS): sel_vs_kx_loose fixes the y-axis to SELEC_BOUNDS (rather than
+# auto-scaling) so it matches sel_vs_targ1_aff's y-axis for side-by-side placement.
+COMPARISON_SHAPES["sel_vs_kx_loose"] = {**COMPARISON_SHAPES["sel_vs_kx"], "ylim": SELEC_BOUNDS}
+COMPARISON_SHAPES["sel_vs_targ1_aff"] = _row(
+    _axes("aff1", "sel"),
+    r"Target receptor K$_{a}$ (log$_{10}$(M))",
+    SELECTIVITY_XLABEL,
+    xlim=AFFINITY_BOUNDS,
+    ylim=SELEC_BOUNDS,
+    yrefs=(0.5,),
+)
+
+# The bulk reference grid (fig-scatter-grid) renders exactly these 8 comparisons;
 # SPECIFIC_ANALYSES entries reference COMPARISON_SHAPES directly and never touch this list.
 GRID_COMPARISON_KEYS = [
     "sel_vs_kx",
@@ -452,20 +349,14 @@ def scan_base_arrays(scan):
     return {
         "kx": df["Kx_star"].to_numpy(),
         "sel": df["Selectivity"].to_numpy(),
-        "aff0": df["Affinity_Receptor_0"].to_numpy(),
-        "aff1": df["Affinity_Receptor_1"].to_numpy(),
-        "aff2": df["Affinity_Receptor_2"].to_numpy(),
+        **{r["sd_key"]: df[r["csv_col"]].to_numpy() for r in RECEPTORS},
         "log2_gain": df["log2_gain"].to_numpy(),
     }
 
 
 # Color every point by the gain of the scan named in that scan's "gain_ref": its own gain used
 # directly, or another scan's gain mapped onto these coordinates by pair key (unmatched pairs get
-# NaN -> gray). Pointing the tight scan at the loose scan shows where the loose-bound-synergistic
-# pairs land once Kx* is capped. The direct self-reference path matters for asymmetric-valency
-# scans, which optimize both receptor orderings per pair (two distinct designs): pair_key sorts the
-# receptors, so routing such a scan's own gain through the key would collapse those orderings onto
-# one key. Cross-scan mapping still requires the reference scan's keys to be unique.
+# NaN -> gray).
 scan_colors_gain = {}
 for scan in SCANS:
     label, ref = scan["label"], scan["gain_ref"]
@@ -482,11 +373,6 @@ for scan in SCANS:
 
 gain_norm = Normalize(vmin=0, vmax=GAIN_COLOR_MAX)
 
-# Cell types actually present across this file's loaded scans, in the project-wide
-# canonical order (see bicytok.figure_styles.CELL_TYPES): every color_by="cell_type"
-# SPECIFIC_ANALYSES panel and fig-celltype-legend below look colors up in the shared
-# CELL_TYPE_COLORS, so a given cell type gets the same color here as it does in
-# scan_comparison_scatter.qmd and any other all-cell-type analysis, not just within this file.
 ALL_CELL_TYPES = sorted(
     set().union(*(df["Cell_Type"].unique() for df in pair_dfs.values())),
     key=CELL_TYPES.index,
@@ -507,9 +393,7 @@ def draw_gain_points(
         rasterized=RASTERIZE,
         zorder=1,
     )
-    synergistic = (
-        cvals > 0
-    )  # NaN (unmatched) is False here, so those stay in the gray cloud
+    synergistic = cvals > 0  # NaN (unmatched) is False here, so those stay in the gray cloud
     order = np.argsort(cvals[synergistic])  # strongest synergy drawn last
     return ax.scatter(
         x[synergistic][order],
@@ -556,14 +440,11 @@ def _draw_comparison_panel(
     """Draw one comparison panel (one comparison x one scan) onto ax.
 
     aux_vals: per-point color-driving values — log2 gain for color_by="gain" (continuous,
-    paired with a colorbar) or cell-type labels for color_by="cell_type" (categorical; see
-    the shared CELL_TYPE_COLORS mapping and fig-celltype-legend, not repeated per panel).
+    paired with a colorbar) or cell-type labels for color_by="cell_type" (categorical).
     point_size_bg/point_size_fg default to the bulk grid's own (small, ~276k-point-tuned)
-    sizes; pass POINT_SIZE_BACKGROUND/POINT_SIZE_FOREGROUND for a standalone panel sized
-    like the rest of the manuscript's scatter figures. Shared by the bulk grid and
-    single-panel manuscript extracts so both paths stay in sync.
-    Returns the colorbar mappable for color_by="gain" (None for "cell_type"), for the
-    caller to finish the figure.
+    sizes; pass POINT_SIZE_XS/POINT_SIZE_BACKGROUND for a standalone panel sized like the
+    rest of the manuscript's scatter figures. Returns the colorbar mappable for
+    color_by="gain" (None for "cell_type").
     """
     x, y, aux = comp["get"](sd, aux_vals)
     if color_by == "cell_type":
@@ -585,19 +466,11 @@ def _draw_comparison_panel(
     return result
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Shared histogram helper
-# ═══════════════════════════════════════════════════════════════════════════════
+# ── Shared histogram helper ─────────────────────────────────────────────────────────
 
 
 def overlay_hist(
-    ax,
-    data_by_scan,
-    bins,
-    scan_bounds=None,
-    annotate_pinned=False,
-    ref_lines=(),
-    logy=False,
+    ax, data_by_scan, bins, scan_bounds=None, annotate_pinned=False, ref_lines=(), logy=False
 ):
     """Overlay per-scan density histograms of one output on ax.
 
@@ -605,13 +478,11 @@ def overlay_hist(
         scan's color; with annotate_pinned, the fraction of pairs within PIN_TOL of
         the bound is labeled.
     ref_lines: x-values drawn as shared gray reference lines (e.g. affinity bounds).
-    logy: use a log-scaled density axis.
     """
     for scan in ACTIVE_SCANS:
         ax.hist(
             data_by_scan[scan["label"]],
             bins=bins,
-            density=False,
             alpha=0.55,
             color=scan["color"],
             label=scan["label"],
@@ -642,14 +513,8 @@ def overlay_hist(
                 )
 
 
-def overlay_figure(
-    data_by_scan, bins, xlabel, ylabel, legend_loc, xlim=None, **hist_kwargs
-):
-    """Single-axis overlaid-histogram figure: overlay per-scan histograms, then label and show.
-
-    xlim defaults to the bin span; pass it to override (e.g. clip the selectivity axis at 1).
-    hist_kwargs pass through to overlay_hist (scan_bounds, annotate_pinned, ref_lines, logy).
-    """
+def overlay_figure(data_by_scan, bins, xlabel, ylabel, legend_loc, xlim=None, **hist_kwargs):
+    """Single-axis overlaid-histogram figure. hist_kwargs pass through to overlay_hist."""
     fig, ax = plt.subplots(figsize=FIGSIZE["single_panel"])
     overlay_hist(ax, data_by_scan, bins, **hist_kwargs)
     ax.set_xlim(*(xlim if xlim is not None else (bins[0], bins[-1])))
@@ -660,19 +525,16 @@ def overlay_figure(
     plt.show()
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Thin figure-generation functions — one per analysis type, in the order they're
-# rendered below: specific single-panel figures, parameter histograms, scatter grid.
-# ═══════════════════════════════════════════════════════════════════════════════
+# ── Thin figure-generation functions — one per analysis type, in the order they're
+# rendered below: specific single-panel figures, parameter histograms, scatter grid. ──
 
 
 def plot_specific_analysis(key):
-    """Render one specific single-panel analysis from SPECIFIC_ANALYSES as a standalone figure.
+    """Render one SPECIFIC_ANALYSES entry as a standalone figure.
 
-    color_by="cell_type" panels omit their legend (see the shared fig-celltype-legend cell
-    instead); color_by="gain" panels get a colorbar, sized via FIGSIZE["square_scatter_
-    with_colorbar"] + COLORBAR_FRACTION/COLORBAR_PAD so the plot area still matches
-    FIGSIZE["square_scatter"] rather than being squeezed narrower by the colorbar.
+    color_by="cell_type" panels omit their legend (see fig-celltype-legend instead);
+    color_by="gain" panels get a colorbar, sized via FIGSIZE["square_scatter_with_colorbar"]
+    so the plot area still matches FIGSIZE["square_scatter"].
     """
     spec = SPECIFIC_ANALYSES[key]
     comp = COMPARISON_SHAPES[spec["comparison"]]
@@ -718,16 +580,12 @@ def plot_specific_analysis(key):
         )
 
     set_tick_count(ax, 3, None)
-
     plt.tight_layout()
     plt.show()
 
 
 def plot_celltype_legend():
-    """Detached legend shared by every color_by="cell_type" SPECIFIC_ANALYSES panel: each
-    such panel omits its own legend, so this one legend covers all of them and can be
-    positioned independently (e.g. in Illustrator).
-    """
+    """Detached legend shared by every color_by="cell_type" SPECIFIC_ANALYSES panel."""
     handles = [
         mlines.Line2D([], [], marker="o", linestyle="None", color=CELL_TYPE_COLORS[ct])
         for ct in ALL_CELL_TYPES
@@ -736,36 +594,36 @@ def plot_celltype_legend():
     plt.show()
 
 
-# Concatenations below draw only from ACTIVE_SCANS labels, so bin ranges aren't stretched by
-# data (e.g. the high-valency scans) that these figures never actually plot.
-_active_labels = [s["label"] for s in ACTIVE_SCANS]
+# Bin ranges are computed only from ACTIVE_SCANS' data, so they aren't stretched by data
+# (e.g. the high-valency scans) that these figures never actually plot.
+active_dfs = {lbl: df for lbl, df in scan_dfs.items() if lbl in ACTIVE_SCAN_LABELS}
+active_pair_dfs = {lbl: df for lbl, df in pair_dfs.items() if lbl in ACTIVE_SCAN_LABELS}
 
-kx_by_scan = {lbl: df["Kx_star"].to_numpy() for lbl, df in scan_dfs.items()}
-_all_kx = np.concatenate([kx_by_scan[lbl] for lbl in _active_labels])
+kx_by_scan = {lbl: df["Kx_star"].to_numpy() for lbl, df in active_dfs.items()}
+_all_kx = np.concatenate(list(kx_by_scan.values()))
 KX_BINS = np.arange(np.floor(_all_kx.min()), np.ceil(_all_kx.max()) + 0.2, 0.2)
 
 # Diagonal (rec == rec) pairs are excluded: those are modeled as a single target with
 # combined valency, so the second target receptor has valency 0 and its affinity is never
 # optimized (it stays at its initialization value).
-off_diag_dfs = {
-    lbl: df[df["Receptor_1"] != df["Receptor_2"]] for lbl, df in scan_dfs.items()
+off_diag_by_scan = {
+    lbl: df[df["Receptor_1"] != df["Receptor_2"]] for lbl, df in active_dfs.items()
 }
 AFF_BINS = np.arange(AFFINITY_BOUNDS[0], AFFINITY_BOUNDS[1] + 0.2, 0.2)
 
-sel_by_scan = {lbl: df["Selectivity"].to_numpy() for lbl, df in scan_dfs.items()}
-_all_sel = np.concatenate([sel_by_scan[lbl] for lbl in _active_labels])
+sel_by_scan = {lbl: df["Selectivity"].to_numpy() for lbl, df in active_dfs.items()}
+_all_sel = np.concatenate(list(sel_by_scan.values()))
 SEL_BINS = np.linspace(_all_sel.min(), 1.0, 60)
 
-gain_by_scan = {lbl: df["log2_gain"].to_numpy() for lbl, df in pair_dfs.items()}
-_all_gain = np.concatenate([gain_by_scan[lbl] for lbl in _active_labels])
+gain_by_scan = {lbl: df["log2_gain"].to_numpy() for lbl, df in active_pair_dfs.items()}
+_all_gain = np.concatenate(list(gain_by_scan.values()))
 GAIN_BINS = np.linspace(_all_gain.min(), _all_gain.max(), 70)
 
 
 def plot_kxstar_dist():
-    """Overlaid density histograms of optimal log10(Kx*), with each scan's upper bound marked.
-
-    Histograms (not KDEs) are used so the pile-up of pairs pinned at a scan's upper bound
-    is preserved rather than smeared.
+    """Overlaid density histograms of optimal log10(Kx*) (not KDEs, so the pile-up of
+    pairs pinned at a scan's upper bound is preserved rather than smeared), with each
+    scan's upper bound marked.
     """
     overlay_figure(
         kx_by_scan,
@@ -779,14 +637,12 @@ def plot_kxstar_dist():
 
 
 def plot_affinity_dist():
-    """Overlaid affinity histograms, one subpanel per receptor (signal, target 1, target 2)."""
-    fig, axes = plt.subplots(
-        1, len(AFF_COLS), figsize=(5 * len(AFF_COLS), 4.8), sharey=True
-    )
-    for ax, (col, title) in zip(axes, AFF_COLS.items(), strict=True):
-        data = {lbl: df[col].to_numpy() for lbl, df in off_diag_dfs.items()}
+    """Overlaid affinity histograms, one subpanel per receptor in RECEPTORS."""
+    fig, axes = plt.subplots(1, len(RECEPTORS), figsize=(5 * len(RECEPTORS), 4.8), sharey=True)
+    for ax, r in zip(axes, RECEPTORS, strict=True):
+        data = {lbl: df[r["csv_col"]].to_numpy() for lbl, df in off_diag_by_scan.items()}
         overlay_hist(ax, data, AFF_BINS, ref_lines=AFFINITY_BOUNDS)
-        ax.set_title(title)
+        ax.set_title(r["title"])
         ax.set_xlim(*AFFINITY_BOUNDS)
         ax.set_xlabel("Optimal affinity, log10(M)")
     axes[0].set_ylabel("Number of pairs")
@@ -836,17 +692,11 @@ def _sync_row(axes_row):
 def build_comparison_grid():
     """Draw the full comparison grid (rows = GRID_COMPARISON_KEYS, cols = ACTIVE_SCANS).
 
-    One grid gathering every per-pair scatter from GRID_COMPARISON_KEYS: rows are
-    comparisons, columns are scans (loose bound left, tight bound right). The first four
-    rows put each output on y vs. optimal log10(Kx*) on x; the last three put log2
-    selectivity gain on y vs. an output on x. Every panel uses the same coloring: all pairs
-    in gray for context, with pairs that are synergistic in that scan's reference scan (its
-    "gain_ref") overlaid and colored by the reference scan's log2 gain (strongest drawn
-    last). Pointing the tight scan at the loose scan maps the loose-bound gain onto the
-    tight coordinates, so the tight-bound column shows exactly where the once-synergistic
-    pairs are trapped once Kx* is capped — pinned at the wall, driven to the affinity
-    ceiling, gain collapsed to ~0. Points are rasterized (~276k per panel). Axis scales are
-    shared within a row (across scans), not down a column, so x and y labels are set per row.
+    Every panel uses the same coloring: all pairs in gray for context, with pairs
+    synergistic in that scan's reference scan ("gain_ref") overlaid and colored by the
+    reference scan's log2 gain (strongest drawn last) — pointing the tight scan at the
+    loose scan shows where once-synergistic pairs land once Kx* is capped. Axis scales
+    are shared within a row (across scans), not down a column.
     """
     grid_comps = [COMPARISON_SHAPES[k] for k in GRID_COMPARISON_KEYS]
     fig, axes = plt.subplots(
@@ -861,9 +711,7 @@ def build_comparison_grid():
         sd = scan_base_arrays(scan)
         for r, comp in enumerate(grid_comps):
             ax = axes[r, c]
-            drawn = _draw_comparison_panel(
-                ax, comp, scan, sd, scan_colors_gain[scan["label"]]
-            )
+            drawn = _draw_comparison_panel(ax, comp, scan, sd, scan_colors_gain[scan["label"]])
             if drawn is not None:
                 mappable = drawn
             ax.tick_params(labelsize=GRID_TICK_FONTSIZE)

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -54,7 +54,7 @@ SELEC_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv"
 KL_EMD_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_dist_scan_full_filt.csv"
 
 # Each metric spec: (scan path, CSV column, human-readable label)
-METRIC_SELEC = (SELEC_SCAN_PATH, "Selectivity", "Binding model selectivity")
+METRIC_SELEC = (SELEC_SCAN_PATH, "Selectivity", "Binding model")
 METRIC_KL = (KL_EMD_SCAN_PATH, "KL_Divergence", "KL divergence")
 METRIC_EMD = (KL_EMD_SCAN_PATH, "EMD", "EMD")
 
@@ -261,14 +261,14 @@ def plot_outlier_scatter(res, ax):
             zorder=3,
             alpha=0.85,
             s=40,
-            label=f"High {axis_1_label} only",
+            label=f"{axis_1_label} outlier",
         ),
         "high_2": dict(
             color="#FF9F1C",
             zorder=3,
             alpha=0.85,
             s=40,
-            label=f"High {axis_2_label} only",
+            label=f"{axis_2_label} outlier",
         ),
     }.items():
         sub = df[df["category"] == cat]
@@ -283,7 +283,7 @@ def plot_outlier_scatter(res, ax):
             color="#E63946",
             zorder=4,
             alpha=0.85,
-            label="High on both",
+            label="Shared target",
         )
         labeled_both = both_sub.nlargest(N_LABEL, "r")
         if SHOW_TREND_LINES and len(labeled_both) == N_LABEL:

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -31,6 +31,10 @@ representative-distribution analyses drill into the **first** comparison only.
   - Point labels are placed with `adjustText` to minimize overlap
   - `SHOW_TREND_LINES` toggles the OLS fit line, residual threshold lines, and the
     "both"-category Euclidean cutoff arc, for a decluttered points-only view
+  - `SHOW_LEGEND_IN_PANEL` toggles the per-panel legend (off by default; see below)
+- **`suppfig-scan-outliers-legend`**: the categorization legend, detached from the
+  scatter panels above so it can be positioned independently (e.g. in Illustrator)
+  rather than repeated identically in each panel
 - Receptor-feature violin plots and representative pair distributions for the first
   comparison (diagnostics; not embedded)
 
@@ -46,6 +50,7 @@ import yaml
 from adjustText import adjust_text
 
 from bicytok.figure_styles import (
+    COLORS,
     FIGSIZE,
     POINT_SIZE_BACKGROUND,
     POINT_SIZE_FOREGROUND,
@@ -124,6 +129,10 @@ HIGHLIGHT_PAIRS: list[tuple[str, str]] = []
 # Show the OLS fit line, residual threshold lines, and "both"-category Euclidean
 # cutoff arc. Turn off to declutter the figure down to just the categorized points.
 SHOW_TREND_LINES = False
+# Show a legend on each panel. Off by default since all three comparisons share
+# the same categorization scheme; see suppfig-scan-outliers-legend for the
+# detached, shared legend instead (kept separate for easier Illustrator layout).
+SHOW_LEGEND_IN_PANEL = False
 
 
 # ── Load scans ────────────────────────────────────────────────────────────────
@@ -261,21 +270,21 @@ def plot_outlier_scatter(res, ax):
 
     for cat, style in {
         "neither": dict(
-            color="lightgray",
+            color=COLORS["outlier_neither"],
             zorder=1,
             alpha=0.6,
             s=POINT_SIZE_BACKGROUND,
             label="Neither",
         ),
         "high_1": dict(
-            color="#3A86FF",
+            color=COLORS["outlier_metric1"],
             zorder=3,
             alpha=0.85,
             s=POINT_SIZE_FOREGROUND,
             label=f"{axis_1_label} outlier",
         ),
         "high_2": dict(
-            color="#FF9F1C",
+            color=COLORS["outlier_metric2"],
             zorder=3,
             alpha=0.85,
             s=POINT_SIZE_FOREGROUND,
@@ -291,7 +300,7 @@ def plot_outlier_scatter(res, ax):
             both_sub["s1"],
             both_sub["s2"],
             s=POINT_SIZE_FOREGROUND,
-            color="#E63946",
+            color=COLORS["outlier_both"],
             zorder=4,
             alpha=0.85,
             label="Shared target",
@@ -307,7 +316,7 @@ def plot_outlier_scatter(res, ax):
             ax.plot(
                 arc_x[x_mask],
                 arc_y[x_mask],
-                color="#E63946",
+                color=COLORS["outlier_both"],
                 linewidth=1.2,
                 linestyle=":",
                 alpha=0.55,
@@ -321,7 +330,7 @@ def plot_outlier_scatter(res, ax):
             res["user_rows"]["s2"],
             marker="D",
             s=POINT_SIZE_FOREGROUND,
-            color="#9B5DE5",
+            color=COLORS["outlier_user"],
             zorder=6,
             alpha=1.0,
             label="User-specified pairs",
@@ -372,9 +381,13 @@ def plot_outlier_scatter(res, ax):
         ax=ax,
     )
 
-    ax.set_xlabel(axis_1_label)
+    if axis_1_label == "Binding model":
+        ax.set_xlabel(f"{axis_1_label} selectivity")
+    else:
+        ax.set_xlabel(axis_1_label)
     ax.set_ylabel(axis_2_label)
-    ax.legend(loc="best")
+    if SHOW_LEGEND_IN_PANEL:
+        ax.legend(loc="best")
 
 
 def plot_outlier_comparison(key):
@@ -408,6 +421,46 @@ plot_outlier_comparison("emd_selec_cd8tcm")
 ```{python}
 #| label: suppfig-scan-outliers-emd-selec-pdc
 plot_outlier_comparison("emd_selec_pdc")
+```
+
+```{python}
+#| label: suppfig-scan-outliers-legend
+#| fig-cap: "Shared legend for the outlier-comparison scatter plots above"
+# Detached legend: covers all three comparisons above, since they share the same
+# categorization scheme. "Metric 1"/"Metric 2" are generic rather than naming the
+# specific metric (e.g. "KL divergence"), since that varies by comparison — see
+# each panel's own axis labels for the concrete metric names.
+import matplotlib.lines as mlines
+import matplotlib.pyplot as plt
+
+from bicytok.figure_styles import COLORS, standalone_legend_figure
+
+_legend_color_types = [
+    "outlier_neither",
+    "outlier_metric1",
+    "outlier_metric2",
+    "outlier_both",
+]
+if HIGHLIGHT_PAIRS:
+    _legend_color_types.append("outlier_user")
+
+_legend_handles = []
+for color_type in _legend_color_types:
+    marker = "D" if color_type == "outlier_user" else "o"
+    _legend_handles.append(
+        mlines.Line2D([], [], marker=marker, linestyle="None", color=COLORS[color_type])
+    )
+
+_legend_labels = [
+    "Neither",
+    "Metric 1 outlier",
+    "Metric 2 outlier",
+    "Shared target",
+    "User-specified pairs",
+]
+
+standalone_legend_figure(_legend_handles, _legend_labels)
+plt.show()
 ```
 
 ```{python}

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -5,21 +5,21 @@ title: "Receptor Scan Outlier Analysis"
 # Summary
 Compares two receptor scan metrics across all receptor pairs for a chosen target cell
 type, identifying and labeling the pairs that are outliers relative to the overall
-metric-vs-metric trend. A user-defined list of `CONDITIONS` (each a target cell type
-plus a pair of metrics to compare) is swept: one labeled outlier scatter is generated
-per condition and laid out as panels of a single supplemental figure. The subsequent
-receptor-feature and representative-distribution analyses drill into the **first**
-condition only.
+metric-vs-metric trend. A user-defined `COMPARISONS` dict (each a target cell type plus
+a pair of metrics to compare) is swept: one labeled outlier scatter is generated per
+comparison via a thin plotting cell. The subsequent receptor-feature and
+representative-distribution analyses drill into the **first** comparison only.
 
 # Inputs
 - `SELEC_SCAN_PATH`: CSV from `run_selectivity_scan` (binding-model selectivity)
 - `KL_EMD_SCAN_PATH`: CSV from `run_KL_EMD_scan` (KL divergence and EMD)
   Both must have matching `.yaml` files describing the scan type.
-- `CONDITIONS`: list of dicts, each with a `targ_cell_type` and two metric specs
+- `COMPARISONS`: dict mapping key -> a dict with a `targ_cell_type` and two metric specs
   (`metric_1`, `metric_2`), where a metric spec is `(scan_path, csv_column, label)`
 
 # Outputs
-- **`suppfig-scan-outliers`**: one labeled outlier scatter panel per condition
+- **`suppfig-scan-outliers-kl-selec-treg`**: Selectivity vs KL divergence, Treg
+- **`suppfig-scan-outliers-emd-selec-cd8tcm`**: Selectivity vs EMD, CD8 TCM
   - Gray: neither metric is high
   - Blue: residual below lower threshold (metric 1 higher than expected given metric 2)
   - Orange: residual above upper threshold (metric 2 higher than expected given metric 1)
@@ -28,13 +28,14 @@ condition only.
   - Gold stars (★): global top-N pairs by individual-axis metric
   - Purple diamonds (◆): user-specified pairs of interest, always labeled
 - Receptor-feature violin plots and representative pair distributions for the first
-  condition (diagnostics; not embedded)
+  comparison (diagnostics; not embedded)
 
 ```{python}
 %config InlineBackend.figure_formats = ['svg']
 import os
 
 import matplotlib.patheffects as pe
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import yaml
@@ -48,23 +49,23 @@ METRIC_SELEC = (SELEC_SCAN_PATH, "Selectivity", "Binding model selectivity")
 METRIC_KL = (KL_EMD_SCAN_PATH, "KL_Divergence", "KL divergence")
 METRIC_EMD = (KL_EMD_SCAN_PATH, "EMD", "EMD")
 
-# ── Conditions to sweep ───────────────────────────────────────────────────────
-# One outlier scatter is produced per condition. The first condition also drives
+# ── Comparisons to sweep ──────────────────────────────────────────────────────
+# One outlier scatter is produced per comparison. The first comparison also drives
 # the downstream feature and distribution diagnostics.
-CONDITIONS = [
-    {
+COMPARISONS = {
+    "kl_selec_treg": {
         "targ_cell_type": "Treg",
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_KL,
         "axis_norm": "none",
     },
-    {
+    "emd_selec_cd8tcm": {
         "targ_cell_type": "CD8 TCM",
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_EMD,
         "axis_norm": "none",
     },
-]
+}
 
 # ── Shared outlier-detection settings ─────────────────────────────────────────
 # Percentile threshold (0–100) used for the "both" category (both axes independently high)
@@ -100,14 +101,14 @@ def load_scan_flat(path, metric_col, cell_type):
     ).reset_index(drop=True)
 
 
-def compute_outlier_df(condition):
-    """Merge two metrics for one condition, then fit the trend, compute residuals,
+def compute_outlier_df(comparison):
+    """Merge two metrics for one comparison, then fit the trend, compute residuals,
     and categorize each receptor pair. Returns a result dict consumed by the plot
     and diagnostic cells."""
-    path1, col1, label1 = condition["metric_1"]
-    path2, col2, label2 = condition["metric_2"]
-    targ_cell_type = condition["targ_cell_type"]
-    axis_norm = condition["axis_norm"]
+    path1, col1, label1 = comparison["metric_1"]
+    path2, col2, label2 = comparison["metric_2"]
+    targ_cell_type = comparison["targ_cell_type"]
+    axis_norm = comparison["axis_norm"]
 
     scan1 = load_scan_flat(path1, col1, targ_cell_type)
     scan2 = load_scan_flat(path2, col2, targ_cell_type)
@@ -202,7 +203,7 @@ def compute_outlier_df(condition):
 
 
 def plot_outlier_scatter(res, ax):
-    """Draw one condition's labeled outlier scatter onto the given axis."""
+    """Draw one comparison's labeled outlier scatter onto the given axis."""
     df = res["df"]
     axis_1_label, axis_2_label = res["axis_1_label"], res["axis_2_label"]
     slope, intercept = res["slope"], res["intercept"]
@@ -328,9 +329,17 @@ def plot_outlier_scatter(res, ax):
     ax.legend(fontsize=6, loc="best", framealpha=0.8)
 
 
-# Compute all conditions up front; bind the first condition for the diagnostics.
-outlier_results = [compute_outlier_df(c) for c in CONDITIONS]
-_first = outlier_results[0]
+def plot_outlier_comparison(key):
+    """Draw one comparison's labeled outlier scatter as a standalone figure."""
+    fig, ax = plt.subplots(figsize=(7.5, 7))
+    plot_outlier_scatter(outlier_data[key], ax)
+    plt.tight_layout()
+    plt.show()
+
+
+# Compute every comparison up front; bind the first for the downstream diagnostics.
+outlier_data = {key: compute_outlier_df(cfg) for key, cfg in COMPARISONS.items()}
+_first = next(iter(outlier_data.values()))
 df = _first["df"]
 TARG_CELL_TYPE = _first["targ_cell_type"]
 AXIS_1_LABEL = _first["axis_1_label"]
@@ -339,21 +348,18 @@ CELL_CATEGORIZATION = _first["cell_categorization"]
 ```
 
 ```{python}
-#| label: scan-outliers-plot
-import matplotlib.pyplot as plt
-
-n_cond = len(outlier_results)
-fig, axes = plt.subplots(1, n_cond, figsize=(7.5 * n_cond, 7))
-axes = np.atleast_1d(axes)
-for res, ax in zip(outlier_results, axes, strict=True):
-    plot_outlier_scatter(res, ax)
-plt.tight_layout()
-plt.show()
+#| label: suppfig-scan-outliers-kl-selec-treg
+plot_outlier_comparison("kl_selec_treg")
 ```
 
 ```{python}
-# Tabular summary of all annotated receptor pairs, per condition.
-for res in outlier_results:
+#| label: suppfig-scan-outliers-emd-selec-cd8tcm
+plot_outlier_comparison("emd_selec_cd8tcm")
+```
+
+```{python}
+# Tabular summary of all annotated receptor pairs, per comparison.
+for res in outlier_data.values():
     summary = res["all_label_rows"][
         ["rec1", "rec2", "s1", "s2", "r", "category"]
     ].copy()
@@ -376,7 +382,7 @@ for res in outlier_results:
 ```
 
 ```{python}
-# ── Distribution feature analysis by group (first condition only) ─────────────
+# ── Distribution feature analysis by group (first comparison only) ────────────
 # For each receptor appearing in the scan, computes simple 1D distribution
 # features comparing target vs. off-target abundance. Each receptor pair is then
 # summarized by aggregating the features of its two constituent receptors. Violin
@@ -597,7 +603,7 @@ plt.show()
 ```
 
 ```{python}
-# ── Representative pair raw distributions (first condition only) ──────────────
+# ── Representative pair raw distributions (first comparison only) ─────────────
 # For each scatter-plot category, selects N_REPR representative receptor pairs
 # and shows their joint 2D distribution with 1D marginal histograms. Selection
 # criterion per category:

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -45,7 +45,12 @@ import pandas as pd
 import yaml
 from adjustText import adjust_text
 
-from bicytok.figure_styles import FIGSIZE, apply_style
+from bicytok.figure_styles import (
+    FIGSIZE,
+    POINT_SIZE_BACKGROUND,
+    POINT_SIZE_FOREGROUND,
+    apply_style,
+)
 
 apply_style()
 
@@ -255,19 +260,25 @@ def plot_outlier_scatter(res, ax):
     resid_hi, resid_lo = res["resid_hi"], res["resid_lo"]
 
     for cat, style in {
-        "neither": dict(color="lightgray", zorder=1, alpha=0.6, s=18, label="Neither"),
+        "neither": dict(
+            color="lightgray",
+            zorder=1,
+            alpha=0.6,
+            s=POINT_SIZE_BACKGROUND,
+            label="Neither",
+        ),
         "high_1": dict(
             color="#3A86FF",
             zorder=3,
             alpha=0.85,
-            s=40,
+            s=POINT_SIZE_FOREGROUND,
             label=f"{axis_1_label} outlier",
         ),
         "high_2": dict(
             color="#FF9F1C",
             zorder=3,
             alpha=0.85,
-            s=40,
+            s=POINT_SIZE_FOREGROUND,
             label=f"{axis_2_label} outlier",
         ),
     }.items():
@@ -279,7 +290,7 @@ def plot_outlier_scatter(res, ax):
         ax.scatter(
             both_sub["s1"],
             both_sub["s2"],
-            s=40,
+            s=POINT_SIZE_FOREGROUND,
             color="#E63946",
             zorder=4,
             alpha=0.85,
@@ -309,7 +320,7 @@ def plot_outlier_scatter(res, ax):
             res["user_rows"]["s1"],
             res["user_rows"]["s2"],
             marker="D",
-            s=80,
+            s=POINT_SIZE_FOREGROUND,
             color="#9B5DE5",
             zorder=6,
             alpha=1.0,

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -17,7 +17,8 @@ representative-distribution analyses drill into the **first** comparison only.
 - `COMPARISONS`: dict mapping key -> a dict with a `targ_cell_type`, two metric specs
   (`metric_1`, `metric_2`, each `(scan_path, csv_column, label)`), an `axis_norm` mode,
   and a `thresholds` dict of per-axis percentile cutoffs (`high_pct_1`, `high_pct_2`,
-  `resid_pct_1`, `resid_pct_2`) used for outlier categorization
+  `resid_pct_1`, `resid_pct_2`) used for outlier categorization. Any of the four may be
+  set to `None` to disable the category it drives.
 
 # Outputs
 - **`suppfig-scan-outliers-kl-selec-treg`**: Selectivity vs KL divergence, Treg
@@ -25,10 +26,11 @@ representative-distribution analyses drill into the **first** comparison only.
   - Gray: neither metric is high
   - Blue: residual below lower threshold (metric 1 higher than expected given metric 2)
   - Orange: residual above upper threshold (metric 2 higher than expected given metric 1)
-  - Red: high on both axes independently; point size scales with Euclidean distance
-    from the origin (z-score-normalized), with a reference arc at the labeling cutoff
-  - Gold stars (★): global top-N pairs by individual-axis metric
+  - Red: high on both axes independently
   - Purple diamonds (◆): user-specified pairs of interest, always labeled
+  - Point labels are placed with `adjustText` to minimize overlap
+  - `SHOW_TREND_LINES` toggles the OLS fit line, residual threshold lines, and the
+    "both"-category Euclidean cutoff arc, for a decluttered points-only view
 - Receptor-feature violin plots and representative pair distributions for the first
   comparison (diagnostics; not embedded)
 
@@ -41,6 +43,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import yaml
+from adjustText import adjust_text
 
 from bicytok.figure_styles import FIGSIZE, apply_style
 
@@ -62,6 +65,8 @@ METRIC_EMD = (KL_EMD_SCAN_PATH, "EMD", "EMD")
 #   resid_pct_1 / resid_pct_2 — residual cutoff for the high_1 / high_2 categories
 # Comparisons default to these values; override any subset per comparison, e.g.
 # {**DEFAULT_THRESHOLDS, "resid_pct_2": 99}, to tighten an axis that over-flags.
+# Set any of the four to None to disable the category it drives outright, rather
+# than relying on a 0/100 percentile (which always matches the extreme point(s)).
 DEFAULT_THRESHOLDS = {
     "high_pct_1": 90,
     "high_pct_2": 90,
@@ -78,24 +83,42 @@ COMPARISONS = {
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_KL,
         "axis_norm": "none",
-        "thresholds": DEFAULT_THRESHOLDS,
+        "thresholds": {
+            **DEFAULT_THRESHOLDS,
+            "high_pct_1": 95,
+            "resid_pct_1": 0,
+            "resid_pct_2": 96,
+        },
     },
     "emd_selec_cd8tcm": {
         "targ_cell_type": "CD8 TCM",
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_EMD,
         "axis_norm": "none",
-        "thresholds": DEFAULT_THRESHOLDS,
+        "thresholds": {**DEFAULT_THRESHOLDS, "resid_pct_1": None, "resid_pct_2": 94},
+    },
+    "emd_selec_pdc": {
+        "targ_cell_type": "pDC",
+        "metric_1": METRIC_SELEC,
+        "metric_2": METRIC_EMD,
+        "axis_norm": "none",
+        "thresholds": {
+            **DEFAULT_THRESHOLDS,
+            "high_pct_2": 97,
+            "high_pct_1": 97,
+            "resid_pct_2": None,
+        },
     },
 }
 
 # ── Shared outlier-detection settings ─────────────────────────────────────────
 # Number of auto-labeled points per category (high_1, high_2, both)
-N_LABEL = 5
-# Number of globally top-ranked pairs to highlight with a star per axis
-N_TOP_OVERALL = 1
+N_LABEL = 2
 # User-specified receptor pairs to always label (names must match scan data exactly).
 HIGHLIGHT_PAIRS: list[tuple[str, str]] = []
+# Show the OLS fit line, residual threshold lines, and "both"-category Euclidean
+# cutoff arc. Turn off to declutter the figure down to just the categorized points.
+SHOW_TREND_LINES = False
 
 
 # ── Load scans ────────────────────────────────────────────────────────────────
@@ -117,6 +140,11 @@ def load_scan_flat(path, metric_col, cell_type):
     return sub.rename(
         columns={"Receptor_1": "rec1", "Receptor_2": "rec2", metric_col: "metric"}
     ).reset_index(drop=True)
+
+
+def _pct_or_none(series, pct):
+    """Percentile of series, or None if pct is None (disables the category it drives)."""
+    return np.nanpercentile(series, pct) if pct is not None else None
 
 
 def compute_outlier_df(comparison):
@@ -153,17 +181,20 @@ def compute_outlier_df(comparison):
     # Fit trend line & compute residuals.
     slope, intercept = np.polyfit(df["s1"], df["s2"], 1)
     df["resid"] = df["s2"] - (slope * df["s1"] + intercept)
-    resid_lo = np.nanpercentile(df["resid"], thresholds["resid_pct_1"])
-    resid_hi = np.nanpercentile(df["resid"], thresholds["resid_pct_2"])
+    resid_lo = _pct_or_none(df["resid"], thresholds["resid_pct_1"])
+    resid_hi = _pct_or_none(df["resid"], thresholds["resid_pct_2"])
 
-    # Categorize points.
-    thresh1 = np.nanpercentile(df["s1"], thresholds["high_pct_1"])
-    thresh2 = np.nanpercentile(df["s2"], thresholds["high_pct_2"])
-    high1 = df["s1"] >= thresh1
-    high2 = df["s2"] >= thresh2
+    # Categorize points. A None threshold disables the category it drives.
+    thresh1 = _pct_or_none(df["s1"], thresholds["high_pct_1"])
+    thresh2 = _pct_or_none(df["s2"], thresholds["high_pct_2"])
+    no_match = pd.Series(False, index=df.index)
+    high1 = df["s1"] >= thresh1 if thresh1 is not None else no_match
+    high2 = df["s2"] >= thresh2 if thresh2 is not None else no_match
     df["category"] = "neither"
-    df.loc[df["resid"] <= resid_lo, "category"] = "high_1"
-    df.loc[df["resid"] >= resid_hi, "category"] = "high_2"
+    if resid_lo is not None:
+        df.loc[df["resid"] <= resid_lo, "category"] = "high_1"
+    if resid_hi is not None:
+        df.loc[df["resid"] >= resid_hi, "category"] = "high_2"
     df.loc[high1 & high2, "category"] = "both"
 
     # Euclidean distance on z-score-normalized axes so both metrics contribute equally.
@@ -178,11 +209,6 @@ def compute_outlier_df(comparison):
             df[df["category"] == "high_2"].nlargest(N_LABEL, "resid"),
             df[df["category"] == "both"].nlargest(N_LABEL, "r"),
         ]
-    ).drop_duplicates(subset=["rec1", "rec2"])
-
-    # Global top-N pairs per axis (starred).
-    top_overall_rows = pd.concat(
-        [df.nlargest(N_TOP_OVERALL, "s1"), df.nlargest(N_TOP_OVERALL, "s2")]
     ).drop_duplicates(subset=["rec1", "rec2"])
 
     # User-specified pairs.
@@ -202,9 +228,9 @@ def compute_outlier_df(comparison):
         else pd.DataFrame(columns=df.columns)
     )
 
-    all_label_rows = pd.concat(
-        [auto_label_rows, top_overall_rows, user_rows]
-    ).drop_duplicates(subset=["rec1", "rec2"])
+    all_label_rows = pd.concat([auto_label_rows, user_rows]).drop_duplicates(
+        subset=["rec1", "rec2"]
+    )
 
     return {
         "df": df,
@@ -216,7 +242,6 @@ def compute_outlier_df(comparison):
         "intercept": intercept,
         "resid_hi": resid_hi,
         "resid_lo": resid_lo,
-        "top_overall_rows": top_overall_rows,
         "user_rows": user_rows,
         "all_label_rows": all_label_rows,
     }
@@ -249,25 +274,19 @@ def plot_outlier_scatter(res, ax):
         sub = df[df["category"] == cat]
         ax.scatter(sub["s1"], sub["s2"], **style)
 
-    both_sub = df[df["category"] == "both"].copy()
+    both_sub = df[df["category"] == "both"]
     if not both_sub.empty:
-        r_min, r_max = both_sub["r"].min(), both_sub["r"].max()
-        sizes_both = (
-            40 + 200 * (both_sub["r"] - r_min) / (r_max - r_min)
-            if r_max > r_min
-            else np.full(len(both_sub), 80)
-        )
         ax.scatter(
             both_sub["s1"],
             both_sub["s2"],
-            s=sizes_both,
+            s=40,
             color="#E63946",
             zorder=4,
-            alpha=0.95,
-            label="High on both (size ∝ Euclidean dist.)",
+            alpha=0.85,
+            label="High on both",
         )
         labeled_both = both_sub.nlargest(N_LABEL, "r")
-        if len(labeled_both) == N_LABEL:
+        if SHOW_TREND_LINES and len(labeled_both) == N_LABEL:
             r_ref_z = labeled_both["r"].min()
             s1_std, s2_std = df["s1"].std() + 1e-9, df["s2"].std() + 1e-9
             theta_arc = np.linspace(0, np.pi / 2, 200)
@@ -297,55 +316,54 @@ def plot_outlier_scatter(res, ax):
             label="User-specified pairs",
         )
 
-    ax.scatter(
-        res["top_overall_rows"]["s1"],
-        res["top_overall_rows"]["s2"],
-        marker="*",
-        s=220,
-        color="#FFD700",
-        edgecolors="#888",
-        linewidths=0.5,
-        zorder=7,
-        alpha=1.0,
-        label=f"Top-{N_TOP_OVERALL} per axis",
-    )
+    if SHOW_TREND_LINES:
+        x_line = np.array([df["s1"].min(), df["s1"].max()])
+        ax.plot(
+            x_line,
+            slope * x_line + intercept,
+            color="dimgray",
+            linewidth=1.0,
+            linestyle="-",
+            alpha=0.45,
+            zorder=2,
+            label="OLS fit",
+        )
+        if resid_hi is not None:
+            ax.plot(
+                x_line,
+                slope * x_line + intercept + resid_hi,
+                color="darkorange",
+                linewidth=1.0,
+                linestyle="--",
+                alpha=0.5,
+            )
+        if resid_lo is not None:
+            ax.plot(
+                x_line,
+                slope * x_line + intercept + resid_lo,
+                color="steelblue",
+                linewidth=1.0,
+                linestyle="--",
+                alpha=0.5,
+            )
 
-    x_line = np.array([df["s1"].min(), df["s1"].max()])
-    ax.plot(
-        x_line,
-        slope * x_line + intercept,
-        color="dimgray",
-        linewidth=1.0,
-        linestyle="-",
-        alpha=0.45,
-        zorder=2,
-        label="OLS fit",
-    )
-    ax.plot(
-        x_line,
-        slope * x_line + intercept + resid_hi,
-        color="darkorange",
-        linewidth=1.0,
-        linestyle="--",
-        alpha=0.5,
-    )
-    ax.plot(
-        x_line,
-        slope * x_line + intercept + resid_lo,
-        color="steelblue",
-        linewidth=1.0,
-        linestyle="--",
-        alpha=0.5,
-    )
-
+    texts = []
     for _, row in res["all_label_rows"].iterrows():
         label = f"({row['rec1']}, {row['rec2']})"
-        txt = ax.text(row["s1"], row["s2"], label, fontsize=7, ha="left", va="bottom")
+        txt = ax.text(row["s1"], row["s2"], label)
         txt.set_path_effects([pe.withStroke(linewidth=2, foreground="white")])
+        texts.append(txt)
+    adjust_text(
+        texts,
+        x=df["s1"].to_numpy(),
+        y=df["s2"].to_numpy(),
+        arrowprops=dict(arrowstyle="-", lw=1.0, color="#555555", alpha=0.8),
+        ax=ax,
+    )
 
     ax.set_xlabel(axis_1_label)
     ax.set_ylabel(axis_2_label)
-    ax.legend(fontsize=6, loc="best", framealpha=0.8)
+    ax.legend(loc="best")
 
 
 def plot_outlier_comparison(key):
@@ -374,6 +392,11 @@ plot_outlier_comparison("kl_selec_treg")
 ```{python}
 #| label: suppfig-scan-outliers-emd-selec-cd8tcm
 plot_outlier_comparison("emd_selec_cd8tcm")
+```
+
+```{python}
+#| label: suppfig-scan-outliers-emd-selec-pdc
+plot_outlier_comparison("emd_selec_pdc")
 ```
 
 ```{python}

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -40,6 +40,10 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from bicytok.figure_styles import FIGSIZE, apply_style
+
+apply_style()
+
 # ── Scan paths ────────────────────────────────────────────────────────────────
 SELEC_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv"
 KL_EMD_SCAN_PATH = "/home/sama/receptor_sweep_data/20260520_dist_scan_full_filt.csv"
@@ -71,7 +75,7 @@ COMPARISONS = {
 # Percentile threshold (0–100) used for the "both" category (both axes independently high)
 HIGH_PERCENTILE = 90
 # Percentile threshold (0–100) for the residual-based high_1 / high_2 categories.
-RESID_PERCENTILE = 90
+RESID_PERCENTILE = 97
 # Number of auto-labeled points per category (high_1, high_2, both)
 N_LABEL = 5
 # Number of globally top-ranked pairs to highlight with a star per axis
@@ -323,15 +327,14 @@ def plot_outlier_scatter(res, ax):
         txt = ax.text(row["s1"], row["s2"], label, fontsize=7, ha="left", va="bottom")
         txt.set_path_effects([pe.withStroke(linewidth=2, foreground="white")])
 
-    ax.set_xlabel(axis_1_label, fontsize=13)
-    ax.set_ylabel(axis_2_label, fontsize=13)
-    ax.tick_params(labelsize=11)
+    ax.set_xlabel(axis_1_label)
+    ax.set_ylabel(axis_2_label)
     ax.legend(fontsize=6, loc="best", framealpha=0.8)
 
 
 def plot_outlier_comparison(key):
     """Draw one comparison's labeled outlier scatter as a standalone figure."""
-    fig, ax = plt.subplots(figsize=(7.5, 7))
+    fig, ax = plt.subplots(figsize=FIGSIZE["square_scatter"])
     plot_outlier_scatter(outlier_data[key], ax)
     plt.tight_layout()
     plt.show()

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -14,8 +14,10 @@ representative-distribution analyses drill into the **first** comparison only.
 - `SELEC_SCAN_PATH`: CSV from `run_selectivity_scan` (binding-model selectivity)
 - `KL_EMD_SCAN_PATH`: CSV from `run_KL_EMD_scan` (KL divergence and EMD)
   Both must have matching `.yaml` files describing the scan type.
-- `COMPARISONS`: dict mapping key -> a dict with a `targ_cell_type` and two metric specs
-  (`metric_1`, `metric_2`), where a metric spec is `(scan_path, csv_column, label)`
+- `COMPARISONS`: dict mapping key -> a dict with a `targ_cell_type`, two metric specs
+  (`metric_1`, `metric_2`, each `(scan_path, csv_column, label)`), an `axis_norm` mode,
+  and a `thresholds` dict of per-axis percentile cutoffs (`high_pct_1`, `high_pct_2`,
+  `resid_pct_1`, `resid_pct_2`) used for outlier categorization
 
 # Outputs
 - **`suppfig-scan-outliers-kl-selec-treg`**: Selectivity vs KL divergence, Treg
@@ -53,6 +55,20 @@ METRIC_SELEC = (SELEC_SCAN_PATH, "Selectivity", "Binding model selectivity")
 METRIC_KL = (KL_EMD_SCAN_PATH, "KL_Divergence", "KL divergence")
 METRIC_EMD = (KL_EMD_SCAN_PATH, "EMD", "EMD")
 
+# ── Per-axis outlier-detection thresholds ─────────────────────────────────────
+# Percentile thresholds (0–100), applied independently per axis so a comparison
+# with no real outliers along one axis doesn't get false ones forced onto it:
+#   high_pct_1 / high_pct_2  — axis 1 / axis 2 cutoff for the "both" category
+#   resid_pct_1 / resid_pct_2 — residual cutoff for the high_1 / high_2 categories
+# Comparisons default to these values; override any subset per comparison, e.g.
+# {**DEFAULT_THRESHOLDS, "resid_pct_2": 99}, to tighten an axis that over-flags.
+DEFAULT_THRESHOLDS = {
+    "high_pct_1": 90,
+    "high_pct_2": 90,
+    "resid_pct_1": 3,
+    "resid_pct_2": 97,
+}
+
 # ── Comparisons to sweep ──────────────────────────────────────────────────────
 # One outlier scatter is produced per comparison. The first comparison also drives
 # the downstream feature and distribution diagnostics.
@@ -62,20 +78,18 @@ COMPARISONS = {
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_KL,
         "axis_norm": "none",
+        "thresholds": DEFAULT_THRESHOLDS,
     },
     "emd_selec_cd8tcm": {
         "targ_cell_type": "CD8 TCM",
         "metric_1": METRIC_SELEC,
         "metric_2": METRIC_EMD,
         "axis_norm": "none",
+        "thresholds": DEFAULT_THRESHOLDS,
     },
 }
 
 # ── Shared outlier-detection settings ─────────────────────────────────────────
-# Percentile threshold (0–100) used for the "both" category (both axes independently high)
-HIGH_PERCENTILE = 90
-# Percentile threshold (0–100) for the residual-based high_1 / high_2 categories.
-RESID_PERCENTILE = 97
 # Number of auto-labeled points per category (high_1, high_2, both)
 N_LABEL = 5
 # Number of globally top-ranked pairs to highlight with a star per axis
@@ -134,15 +148,17 @@ def compute_outlier_df(comparison):
     axis_1_label = label1 + suffix
     axis_2_label = label2 + suffix
 
+    thresholds = comparison["thresholds"]
+
     # Fit trend line & compute residuals.
     slope, intercept = np.polyfit(df["s1"], df["s2"], 1)
     df["resid"] = df["s2"] - (slope * df["s1"] + intercept)
-    resid_hi = np.nanpercentile(df["resid"], RESID_PERCENTILE)
-    resid_lo = np.nanpercentile(df["resid"], 100 - RESID_PERCENTILE)
+    resid_lo = np.nanpercentile(df["resid"], thresholds["resid_pct_1"])
+    resid_hi = np.nanpercentile(df["resid"], thresholds["resid_pct_2"])
 
     # Categorize points.
-    thresh1 = np.nanpercentile(df["s1"], HIGH_PERCENTILE)
-    thresh2 = np.nanpercentile(df["s2"], HIGH_PERCENTILE)
+    thresh1 = np.nanpercentile(df["s1"], thresholds["high_pct_1"])
+    thresh2 = np.nanpercentile(df["s2"], thresholds["high_pct_2"])
     high1 = df["s1"] >= thresh1
     high2 = df["s2"] >= thresh2
     df["category"] = "neither"

--- a/figures/scanning_analyses/scan_outliers.qmd
+++ b/figures/scanning_analyses/scan_outliers.qmd
@@ -55,6 +55,7 @@ from bicytok.figure_styles import (
     POINT_SIZE_BACKGROUND,
     POINT_SIZE_FOREGROUND,
     apply_style,
+    set_tick_count,
 )
 
 apply_style()
@@ -388,6 +389,8 @@ def plot_outlier_scatter(res, ax):
     ax.set_ylabel(axis_2_label)
     if SHOW_LEGEND_IN_PANEL:
         ax.legend(loc="best")
+
+    set_tick_count(ax, 4, 4)
 
 
 def plot_outlier_comparison(key):

--- a/figures/scanning_analyses/scan_summary_heatmaps.qmd
+++ b/figures/scanning_analyses/scan_summary_heatmaps.qmd
@@ -25,7 +25,7 @@ import numpy as np
 import seaborn as sns
 import yaml
 
-from figures.scanning_analyses.scan_runners import (
+from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )

--- a/figures/scanning_analyses/scan_summary_heatmaps.qmd
+++ b/figures/scanning_analyses/scan_summary_heatmaps.qmd
@@ -157,3 +157,12 @@ cbar.ax.tick_params(width=2, length=6)
 cbar.set_label(f"{metric_label}")
 plt.show()
 ```
+
+```{python}
+# Top receptor pair per cell type, to help match overlapping heatmap labels back to
+# their cell type (uses optimal_pairs computed above, before the position collapse
+# that lets multiple cell types share one heatmap cell).
+print(f"Top receptor pair per cell type ({metric_label}):")
+for cell_type, (rec1, rec2, max_val) in optimal_pairs.items():
+    print(f"  {cell_type}: {rec1} + {rec2} ({max_val:.4f})")
+```

--- a/figures/scanning_analyses/scan_summary_heatmaps.qmd
+++ b/figures/scanning_analyses/scan_summary_heatmaps.qmd
@@ -33,7 +33,7 @@ from bicytok.scan_runners import (
 
 apply_style()
 
-scan_data_path = "/home/sama/receptor_sweep_data/20260604_selec_scan_full_sigCD122.csv"
+scan_data_path = "/home/sama/receptor_sweep_data/20260520_selec_scan_full.csv"
 # For KL_EMD scans: "KL_Divergence" or "EMD". Does nothing for selectivity scans.
 KL_METRIC = "KL_Divergence"
 
@@ -54,7 +54,7 @@ with open(yaml_path) as f:
 if scan_type == "selectivity":
     opt_selec, _, _, receptors, cell_types = load_selec_scan_results(scan_data_path)
     metric_array = opt_selec
-    metric_label = "Selectivity"
+    metric_label = "Binding model selectivity"
 elif scan_type == "KL_EMD":
     KL_results, EMD_results, receptors, cell_types = load_KL_EMD_scan_results(
         scan_data_path
@@ -132,11 +132,11 @@ for (i, j), cts in position_to_cell_types.items():
         color="black",
     )
 if asym_scan:
-    ax.set_xlabel(f"Receptor 2, Valency {scan_valencies[0][2]}")
-    ax.set_ylabel(f"Receptor 1, Valency {scan_valencies[0][1]}")
+    ax.set_xlabel(f"Target 2, Valency {scan_valencies[0][2]}")
+    ax.set_ylabel(f"Target 1, Valency {scan_valencies[0][1]}")
 else:
-    ax.set_xlabel("Receptor 2")
-    ax.set_ylabel("Receptor 1")
+    ax.set_xlabel("Target 2")
+    ax.set_ylabel("Target 1")
 ax.tick_params(axis="x", rotation=90, width=2, length=6)
 ax.tick_params(axis="y", rotation=0, width=2, length=6)
 plt.tight_layout()
@@ -154,6 +154,6 @@ tick_values = np.linspace(vmin_val, vmax_val, num=6)
 cbar.set_ticks(tick_values)
 cbar.set_ticklabels([f"{val:.2f}" for val in tick_values])
 cbar.ax.tick_params(width=2, length=6)
-cbar.set_label(f"Optimal {metric_label}")
+cbar.set_label(f"{metric_label}")
 plt.show()
 ```

--- a/figures/scanning_analyses/scan_summary_heatmaps.qmd
+++ b/figures/scanning_analyses/scan_summary_heatmaps.qmd
@@ -25,10 +25,13 @@ import numpy as np
 import seaborn as sns
 import yaml
 
+from bicytok.figure_styles import CMAPS, FIGSIZE, FONT_SIZE_ANNOT, apply_style
 from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )
+
+apply_style()
 
 scan_data_path = "/home/sama/receptor_sweep_data/20260604_selec_scan_full_sigCD122.csv"
 # For KL_EMD scans: "KL_Divergence" or "EMD". Does nothing for selectivity scans.
@@ -94,10 +97,11 @@ if not asym_scan:
 vmin_val = np.nanmin(summary_matrix)
 vmax_val = np.nanmax(summary_matrix)
 
-fig, ax = plt.subplots(figsize=(8, 8))
+fig, ax = plt.subplots(figsize=FIGSIZE["square_heatmap"])
+ax.grid(False)  # heatmap cells already have their own linewidths/linecolor borders
 sns.heatmap(
     summary_matrix,
-    cmap="Reds",
+    cmap=CMAPS["sequential"],
     xticklabels=filtered_receptors,
     yticklabels=filtered_receptors,
     square=True,
@@ -119,16 +123,22 @@ if not asym_scan:
 for (i, j), cts in position_to_cell_types.items():
     label = "\n".join(cts)
     ax.text(
-        j + 0.5, i + 0.5, label, ha="center", va="center", fontsize=10, color="black"
+        j + 0.5,
+        i + 0.5,
+        label,
+        ha="center",
+        va="center",
+        fontsize=FONT_SIZE_ANNOT,
+        color="black",
     )
 if asym_scan:
-    ax.set_xlabel(f"Receptor 2, Valency {scan_valencies[0][2]}", fontsize=18)
-    ax.set_ylabel(f"Receptor 1, Valency {scan_valencies[0][1]}", fontsize=18)
+    ax.set_xlabel(f"Receptor 2, Valency {scan_valencies[0][2]}")
+    ax.set_ylabel(f"Receptor 1, Valency {scan_valencies[0][1]}")
 else:
-    ax.set_xlabel("Receptor 2", fontsize=18)
-    ax.set_ylabel("Receptor 1", fontsize=18)
-ax.tick_params(axis="x", rotation=90, labelsize=20, width=2, length=6)
-ax.tick_params(axis="y", rotation=0, labelsize=20, width=2, length=6)
+    ax.set_xlabel("Receptor 2")
+    ax.set_ylabel("Receptor 1")
+ax.tick_params(axis="x", rotation=90, width=2, length=6)
+ax.tick_params(axis="y", rotation=0, width=2, length=6)
 plt.tight_layout()
 
 pos = ax.get_position()
@@ -136,13 +146,14 @@ cbar_ax = fig.add_axes(
     [pos.x1 + pos.width * 0.03, pos.y0, pos.width * 0.05, pos.height]
 )
 norm = plt.Normalize(vmin=vmin_val, vmax=vmax_val)
-sm = plt.cm.ScalarMappable(cmap="Reds", norm=norm)
+sm = plt.cm.ScalarMappable(cmap=CMAPS["sequential"], norm=norm)
 sm.set_array([])
 cbar = fig.colorbar(sm, cax=cbar_ax)
+cbar.ax.grid(False)
 tick_values = np.linspace(vmin_val, vmax_val, num=6)
 cbar.set_ticks(tick_values)
 cbar.set_ticklabels([f"{val:.2f}" for val in tick_values])
-cbar.ax.tick_params(labelsize=20, width=2, length=6)
-cbar.set_label(f"Optimal {metric_label}", fontsize=18)
+cbar.ax.tick_params(width=2, length=6)
+cbar.set_label(f"Optimal {metric_label}")
 plt.show()
 ```

--- a/figures/scanning_analyses/scan_synergy.qmd
+++ b/figures/scanning_analyses/scan_synergy.qmd
@@ -47,7 +47,7 @@ import pandas as pd
 import yaml
 
 sys.path.insert(0, ".")
-from scan_runners import load_KL_EMD_scan_results, load_selec_scan_results
+from bicytok.scan_runners import load_KL_EMD_scan_results, load_selec_scan_results
 
 # ── Parameters ────────────────────────────────────────────────────────────────
 # --- Paths to scan results ---

--- a/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
+++ b/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
@@ -45,7 +45,7 @@ import pandas as pd
 import yaml
 from adjustText import adjust_text
 
-from figures.scanning_analyses.scan_runners import (
+from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )

--- a/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
+++ b/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
@@ -54,7 +54,6 @@ from bicytok.figure_styles import (
     FONT_SIZE_ANNOT,
     GRID_ALPHA,
     apply_style,
-    standalone_legend_figure,
 )
 from bicytok.scan_runners import (
     load_KL_EMD_scan_results,

--- a/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
+++ b/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
@@ -45,10 +45,19 @@ import pandas as pd
 import yaml
 from adjustText import adjust_text
 
+from bicytok.figure_styles import (
+    COLORS,
+    FIGSIZE,
+    FONT_SIZE_ANNOT,
+    GRID_ALPHA,
+    apply_style,
+)
 from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
     load_selec_scan_results,
 )
+
+apply_style()
 
 # ── Scan results used across the manuscript ───────────────────────────────────
 # Figure 3 (low valency, symmetric): pairing rarely beats the best single receptor.
@@ -197,7 +206,7 @@ def _spread_labels(values, min_gap=0.015):
 def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
     """Scatter of max 1D vs max 2D per cell type. Blue = 2D ≥ 1D (pairing helps),
     red = 2D < 1D. Blue points are always labeled; red only below decline_threshold."""
-    fig, ax = plt.subplots(figsize=(6, 6))
+    fig, ax = plt.subplots(figsize=FIGSIZE["square_scatter"])
 
     s1d = df["Max 1D"].values
     s2d = df["Max 2D"].values
@@ -213,7 +222,9 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
         zorder=0,
     )
 
-    colors = ["#2274A5" if r >= 1.0 else "#C0392B" for r in df["2D/1D"]]
+    colors = [
+        COLORS["improved"] if r >= 1.0 else COLORS["declined"] for r in df["2D/1D"]
+    ]
     ax.scatter(s1d, s2d, c=colors, s=70, zorder=3, edgecolors="white", linewidths=0.5)
 
     texts = []
@@ -221,13 +232,15 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
         improved = row["2D/1D"] >= 1.0
         declined = row["2D/1D"] < decline_threshold
         if improved or declined:
-            label_color = "#2274A5" if row["2D/1D"] >= 1.0 else "#C0392B"
+            label_color = (
+                COLORS["improved"] if row["2D/1D"] >= 1.0 else COLORS["declined"]
+            )
             texts.append(
                 ax.text(
                     row["Max 1D"],
                     row["Max 2D"],
                     row["Cell Type"],
-                    fontsize=10,
+                    fontsize=FONT_SIZE_ANNOT,
                     color=label_color,
                     alpha=0.9,
                 )
@@ -241,12 +254,12 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
         ax=ax,
     )
 
-    ax.set_xlabel(labels["metric_label_1d"], fontsize=14)
-    ax.set_ylabel(labels["metric_label_2d"], fontsize=14)
+    ax.set_xlabel(labels["metric_label_1d"])
+    ax.set_ylabel(labels["metric_label_2d"])
     improved_handle = mlines.Line2D(
         [],
         [],
-        color="#2274A5",
+        color=COLORS["improved"],
         marker="o",
         linestyle="None",
         markersize=7,
@@ -255,17 +268,16 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
     declined_handle = mlines.Line2D(
         [],
         [],
-        color="#C0392B",
+        color=COLORS["declined"],
         marker="o",
         linestyle="None",
         markersize=7,
         label="2D < 1D",
     )
-    ax.legend(handles=[improved_handle, declined_handle], fontsize=12, loc="upper left")
+    ax.legend(handles=[improved_handle, declined_handle], loc="upper left")
     ax.set_xlim(lim_low, lim_high)
     ax.set_ylim(lim_low, lim_high)
     ax.set_aspect("equal")
-    ax.grid(True, alpha=0.25)
     plt.tight_layout()
     plt.show()
 
@@ -278,12 +290,13 @@ def plot_slope(df, labels):
 
     fig, ax = plt.subplots(figsize=(5.5, max(5, len(df_slope) * 0.45)))
     for idx, (_, row) in enumerate(df_slope.iterrows()):
-        color = "#2274A5" if row["Max 2D"] >= row["Max 1D"] else "#C0392B"
+        color = (
+            COLORS["improved"] if row["Max 2D"] >= row["Max 1D"] else COLORS["declined"]
+        )
         ax.plot(
             [0, 1],
             [row["Max 1D"], row["Max 2D"]],
             color=color,
-            linewidth=1.5,
             alpha=0.75,
             zorder=2,
         )
@@ -294,7 +307,7 @@ def plot_slope(df, labels):
             row["Cell Type"],
             ha="right",
             va="center",
-            fontsize=10,
+            fontsize=FONT_SIZE_ANNOT,
             color=color,
         )
         ax.text(
@@ -303,18 +316,18 @@ def plot_slope(df, labels):
             row["Cell Type"],
             ha="left",
             va="center",
-            fontsize=10,
+            fontsize=FONT_SIZE_ANNOT,
             color=color,
         )
 
     ax.set_xticks([0, 1])
-    ax.set_xticklabels(["1D\n(single receptor)", "2D\n(receptor pair)"], fontsize=14)
+    ax.set_xticklabels(["1D\n(single receptor)", "2D\n(receptor pair)"])
     ax.set_xlim(-0.45, 1.45)
-    ax.set_ylabel(f"Max {labels['metric_name']}", fontsize=16)
+    ax.set_ylabel(f"Max {labels['metric_name']}")
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
-    ax.grid(axis="y", alpha=0.25)
+    ax.grid(axis="y", alpha=GRID_ALPHA)
     plt.tight_layout()
     plt.show()
 
@@ -325,7 +338,10 @@ def plot_gain_bars(df, labels):
     df_log = df.sort_values("log2(2D/1D)", ascending=True).reset_index(drop=True)
 
     fig, ax = plt.subplots(figsize=(max(5, len(df_log) * 0.65), 4.5))
-    bar_colors = ["#2274A5" if v >= 0 else "#C0392B" for v in df_log["log2(2D/1D)"]]
+    bar_colors = [
+        COLORS["improved"] if v >= 0 else COLORS["declined"]
+        for v in df_log["log2(2D/1D)"]
+    ]
     bars = ax.bar(
         df_log["Cell Type"],
         df_log["log2(2D/1D)"],
@@ -351,7 +367,7 @@ def plot_gain_bars(df, labels):
             f"{raw_val:.3f}×",
             ha="center",
             va=va,
-            fontsize=10,
+            fontsize=FONT_SIZE_ANNOT,
         )
 
     y_min_data = df_log["log2(2D/1D)"].min()
@@ -362,11 +378,11 @@ def plot_gain_bars(df, labels):
         max(y_max_data + y_pad, 0.02),
     )
 
-    ax.set_ylabel(labels["log2_gain_label"], fontsize=16)
-    ax.set_xticklabels(df_log["Cell Type"], rotation=35, ha="right", fontsize=12)
+    ax.set_ylabel(labels["log2_gain_label"])
+    ax.set_xticklabels(df_log["Cell Type"], rotation=35, ha="right")
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
-    ax.grid(axis="y", alpha=0.25)
+    ax.grid(axis="y", alpha=GRID_ALPHA)
     plt.tight_layout()
     plt.show()
 

--- a/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
+++ b/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
@@ -30,10 +30,8 @@ scans are instantiated:
 - `SCATTER_LABEL_DECLINE_THRESHOLD`: label red points only if 2D/1D ratio is below this
 
 # Outputs
-- **`fig-top-hits-1d-2d-lowval` / `-highval`**: scatter, max 1D vs max 2D per cell type
-- **`fig-top-hits-legend`**: the "Pairing helps" / "Pairing hurts" legend, detached from
-  the two scatter panels above so it can be positioned independently (e.g. in
-  Illustrator) rather than repeated identically in each panel
+- **`fig-top-hits-1d-2d-lowval` / `-highval`**: scatter, max 1D vs max 2D per cell type,
+  with an inline "Pairing helps" / "Pairing hurts" legend in the lower right
 - **`suppfig-top-hits-gain-lowval` / `-highval`**: log₂(2D/1D) gain bars per cell type
 - Slope charts (diagnostic, not embedded): connected strip plot per cell type
 
@@ -70,11 +68,6 @@ HIGHVAL_SCAN = "/home/sama/receptor_sweep_data/20260608_selec_scan_full_mix-val.
 
 # Label red points only if the 2D/1D ratio drops below this threshold.
 SCATTER_LABEL_DECLINE_THRESHOLD = 0.99
-
-# Show a legend on each scatter panel. Off by default since both scan panels share the
-# same "Pairing helps" / "Pairing hurts" coloring; see fig-top-hits-legend for the
-# detached, shared legend instead (kept separate for easier Illustrator layout).
-DISP_LEGEND = False
 
 
 def top_hits_df(scan_path, kl_emd_metric="EMD"):
@@ -221,6 +214,13 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
 
     lim_low = min(s1d.min(), s2d.min()) * 0.995
     lim_high = max(s1d.max(), s2d.max()) * 1.005
+    # Fix the axes bounds before adjust_text runs: it reads the axes' current pixel
+    # extent to keep labels inside (ensure_inside_axes=True), so setting the final
+    # bounds only afterward (via set_xlim/set_ylim) let labels stray past them, which
+    # matplotlib then counts toward the saved figure's size.
+    ax.set_xlim(lim_low, lim_high)
+    ax.set_ylim(lim_low, lim_high)
+    ax.set_aspect("equal")
     ax.plot(
         [lim_low, lim_high],
         [lim_low, lim_high],
@@ -264,29 +264,25 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
 
     ax.set_xlabel(labels["metric_label_1d"])
     ax.set_ylabel(labels["metric_label_2d"])
-    if DISP_LEGEND:
-        improved_handle = mlines.Line2D(
-            [],
-            [],
-            color=COLORS["improved"],
-            marker="o",
-            linestyle="None",
-            markersize=7,
-            label="Pairing helps",
-        )
-        declined_handle = mlines.Line2D(
-            [],
-            [],
-            color=COLORS["declined"],
-            marker="o",
-            linestyle="None",
-            markersize=7,
-            label="Pairing hurts",
-        )
-        ax.legend(handles=[improved_handle, declined_handle], loc="upper left")
-    ax.set_xlim(lim_low, lim_high)
-    ax.set_ylim(lim_low, lim_high)
-    ax.set_aspect("equal")
+    improved_handle = mlines.Line2D(
+        [],
+        [],
+        color=COLORS["improved"],
+        marker="o",
+        linestyle="None",
+        markersize=7,
+        label="Pairing helps",
+    )
+    declined_handle = mlines.Line2D(
+        [],
+        [],
+        color=COLORS["declined"],
+        marker="o",
+        linestyle="None",
+        markersize=7,
+        label="Pairing hurts",
+    )
+    ax.legend(handles=[improved_handle, declined_handle], loc="lower right")
     plt.tight_layout()
     plt.show()
 
@@ -401,6 +397,8 @@ df_low, labels_low = top_hits_df(LOWVAL_SCAN)
 df_high, labels_high = top_hits_df(HIGHVAL_SCAN)
 ```
 
+## Top hits scatters
+
 ```{python}
 #| label: fig-top-hits-1d-2d-lowval
 plot_scatter(df_low, labels_low)
@@ -411,41 +409,15 @@ plot_scatter(df_low, labels_low)
 plot_scatter(df_high, labels_high)
 ```
 
-```{python}
-#| label: fig-top-hits-legend
-#| fig-cap: "Shared legend for the 1D-vs-2D scatter plots above"
-# Detached legend, mirroring fig-scan-comp-celltype-legend (scan_comparison_scatter.qmd)
-# and fig-celltype-legend (scan_kxstar_bounds.qmd): both scatter panels above share the
-# same "Pairing helps" / "Pairing hurts" coloring and omit their own legend, so this one
-# legend covers both and can be positioned independently (e.g. in Illustrator).
-_top_hits_improved_handle = mlines.Line2D(
-    [],
-    [],
-    color=COLORS["improved"],
-    marker="o",
-    linestyle="None",
-    markersize=7,
-)
-_top_hits_declined_handle = mlines.Line2D(
-    [],
-    [],
-    color=COLORS["declined"],
-    marker="o",
-    linestyle="None",
-    markersize=7,
-)
-standalone_legend_figure(
-    [_top_hits_improved_handle, _top_hits_declined_handle],
-    ["Pairing helps", "Pairing hurts"],
-)
-plt.show()
-```
+## Top hits slope chart
 
 ```{python}
 # Slope charts (diagnostic; not embedded).
 plot_slope(df_low, labels_low)
 plot_slope(df_high, labels_high)
 ```
+
+## Top hits gain bar plot
 
 ```{python}
 #| label: top-hits-gain-lowval

--- a/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
+++ b/figures/scanning_analyses/scan_top_hits_1Dvs2D.qmd
@@ -31,6 +31,9 @@ scans are instantiated:
 
 # Outputs
 - **`fig-top-hits-1d-2d-lowval` / `-highval`**: scatter, max 1D vs max 2D per cell type
+- **`fig-top-hits-legend`**: the "Pairing helps" / "Pairing hurts" legend, detached from
+  the two scatter panels above so it can be positioned independently (e.g. in
+  Illustrator) rather than repeated identically in each panel
 - **`suppfig-top-hits-gain-lowval` / `-highval`**: log₂(2D/1D) gain bars per cell type
 - Slope charts (diagnostic, not embedded): connected strip plot per cell type
 
@@ -51,6 +54,7 @@ from bicytok.figure_styles import (
     FONT_SIZE_ANNOT,
     GRID_ALPHA,
     apply_style,
+    standalone_legend_figure,
 )
 from bicytok.scan_runners import (
     load_KL_EMD_scan_results,
@@ -67,6 +71,11 @@ HIGHVAL_SCAN = "/home/sama/receptor_sweep_data/20260608_selec_scan_full_mix-val.
 
 # Label red points only if the 2D/1D ratio drops below this threshold.
 SCATTER_LABEL_DECLINE_THRESHOLD = 0.99
+
+# Show a legend on each scatter panel. Off by default since both scan panels share the
+# same "Pairing helps" / "Pairing hurts" coloring; see fig-top-hits-legend for the
+# detached, shared legend instead (kept separate for easier Illustrator layout).
+DISP_LEGEND = False
 
 
 def top_hits_df(scan_path, kl_emd_metric="EMD"):
@@ -103,8 +112,8 @@ def top_hits_df(scan_path, kl_emd_metric="EMD"):
         metric_name = "Selectivity"
         labels = {
             "metric_name": metric_name,
-            "metric_label_1d": "Max 1D Selectivity (single receptor)",
-            "metric_label_2d": "Max 2D Selectivity (receptor pair)",
+            "metric_label_1d": "Max single-target selectivity",
+            "metric_label_2d": "Max target-pair selectivity",
             "log2_gain_label": "log₂(2D / 1D Selectivity)",
         }
     else:  # KL_EMD
@@ -256,25 +265,26 @@ def plot_scatter(df, labels, decline_threshold=SCATTER_LABEL_DECLINE_THRESHOLD):
 
     ax.set_xlabel(labels["metric_label_1d"])
     ax.set_ylabel(labels["metric_label_2d"])
-    improved_handle = mlines.Line2D(
-        [],
-        [],
-        color=COLORS["improved"],
-        marker="o",
-        linestyle="None",
-        markersize=7,
-        label="2D ≥ 1D (pairing helps)",
-    )
-    declined_handle = mlines.Line2D(
-        [],
-        [],
-        color=COLORS["declined"],
-        marker="o",
-        linestyle="None",
-        markersize=7,
-        label="2D < 1D",
-    )
-    ax.legend(handles=[improved_handle, declined_handle], loc="upper left")
+    if DISP_LEGEND:
+        improved_handle = mlines.Line2D(
+            [],
+            [],
+            color=COLORS["improved"],
+            marker="o",
+            linestyle="None",
+            markersize=7,
+            label="Pairing helps",
+        )
+        declined_handle = mlines.Line2D(
+            [],
+            [],
+            color=COLORS["declined"],
+            marker="o",
+            linestyle="None",
+            markersize=7,
+            label="Pairing hurts",
+        )
+        ax.legend(handles=[improved_handle, declined_handle], loc="upper left")
     ax.set_xlim(lim_low, lim_high)
     ax.set_ylim(lim_low, lim_high)
     ax.set_aspect("equal")
@@ -400,6 +410,36 @@ plot_scatter(df_low, labels_low)
 ```{python}
 #| label: fig-top-hits-1d-2d-highval
 plot_scatter(df_high, labels_high)
+```
+
+```{python}
+#| label: fig-top-hits-legend
+#| fig-cap: "Shared legend for the 1D-vs-2D scatter plots above"
+# Detached legend, mirroring fig-scan-comp-celltype-legend (scan_comparison_scatter.qmd)
+# and fig-celltype-legend (scan_kxstar_bounds.qmd): both scatter panels above share the
+# same "Pairing helps" / "Pairing hurts" coloring and omit their own legend, so this one
+# legend covers both and can be positioned independently (e.g. in Illustrator).
+_top_hits_improved_handle = mlines.Line2D(
+    [],
+    [],
+    color=COLORS["improved"],
+    marker="o",
+    linestyle="None",
+    markersize=7,
+)
+_top_hits_declined_handle = mlines.Line2D(
+    [],
+    [],
+    color=COLORS["declined"],
+    marker="o",
+    linestyle="None",
+    markersize=7,
+)
+standalone_legend_figure(
+    [_top_hits_improved_handle, _top_hits_declined_handle],
+    ["Pairing helps", "Pairing hurts"],
+)
+plt.show()
 ```
 
 ```{python}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ requires-python = ">= 3.13"
 [project.scripts]
 fbuild = "bicytok.figures.common:genFigure"
 distanceCSV = "bicytok.distance_metric_funcs:make_2D_distance_metrics"
-selectivity_scan = "figures.scanning_analyses.scan_runners:run_selectivity_scan"
-KL_EMD_scan = "figures.scanning_analyses.scan_runners:run_KL_EMD_scan"
-filt_scan = "figures.scanning_analyses.scan_runners:filter_scan_by_target_expr"
+selectivity_scan = "bicytok.scan_runners:run_selectivity_scan"
+KL_EMD_scan = "bicytok.scan_runners:run_KL_EMD_scan"
+filt_scan = "bicytok.scan_runners:filter_scan_by_target_expr"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
This pull request performs three functions:
- Consolidates figure style parameters into a single, shared set of hardcoded values in `bicytok/figure_styles.py`. This file defines common font sizes, figure sizes, color schemes, helper functions, and more.
- Cleans up various figure outputs by wiring in shared figure styles.
- Prepares various figures for use in publication. Specifically, the pull request reformats some figures to render multiple distinct instances of the same figure with slightly different input data. This will be key for comparing different target pair sweep results in a manuscript and in other presentation formats.
- Adds a figure that illustrates the distributions (1D and joint) of different optimal binding model parameters. The figure is set up to show the effects of increasing valency on selectivity and target pair synergy gain as well as the effect of setting stricter Kx* bounds on various binding model parameters.
- Adds a figure to illustrate the flow of target pairs between different categories from sweep to sweep. It is currently set up to show the increase in high-selectivity, high-synergy gain pairs with increased valency.